### PR TITLE
Fix serialization of UPath

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
-from pathlib import Path
-
 import nox
+from pathlib import Path
 
 
 @nox.session(python=False)
@@ -29,7 +28,7 @@ def install(session):
 @nox.session(python=False)
 def smoke(session):
     session.install(*"pytest aiohttp requests gcsfs".split())
-    session.run(*"pytest --skiphdfs -vv -s upath".split())
+    session.run(*"pytest --skiphdfs -vv upath".split())
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ def install(session):
 @nox.session(python=False)
 def smoke(session):
     session.install(*"pytest aiohttp requests gcsfs".split())
-    session.run(*"pytest --skiphdfs upath".split())
+    session.run(*"pytest --skiphdfs -vv upath".split())
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ def install(session):
 @nox.session(python=False)
 def smoke(session):
     session.install(*"pytest aiohttp requests gcsfs".split())
-    session.run(*"pytest --skiphdfs -vv upath".split())
+    session.run(*"pytest --skiphdfs -vv upath -k test_pickling".split())
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
-import nox
 from pathlib import Path
+
+import nox
 
 
 @nox.session(python=False)
@@ -28,7 +29,7 @@ def install(session):
 @nox.session(python=False)
 def smoke(session):
     session.install(*"pytest aiohttp requests gcsfs".split())
-    session.run(*"pytest --skiphdfs -vv upath -k test_pickling".split())
+    session.run(*"pytest --skiphdfs -s -vv upath -k test_pickling".split())
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ def install(session):
 @nox.session(python=False)
 def smoke(session):
     session.install(*"pytest aiohttp requests gcsfs".split())
-    session.run(*"pytest --skiphdfs -s -vv upath -k test_pickling".split())
+    session.run(*"pytest --skiphdfs -vv -s upath".split())
 
 
 @nox.session(python=False)

--- a/upath/core.py
+++ b/upath/core.py
@@ -333,6 +333,8 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         kwargs = state["_kwargs"].copy()
         kwargs["_url"] = self._url
         self._kwargs = kwargs
+        # _init needs to be called again, because when __new__ called _init,
+        # the _kwargs were not yet set
         self._init()
 
     def __reduce__(self):

--- a/upath/core.py
+++ b/upath/core.py
@@ -280,8 +280,8 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         # can be implemented, but may be tricky
         raise NotImplementedError
 
-    def touch(self, trunicate=True, **kwargs):
-        self._accessor.touch(self, trunicate=trunicate, **kwargs)
+    def touch(self, truncate=True, **kwargs):
+        self._accessor.touch(self, truncate=truncate, **kwargs)
 
     def unlink(self, missing_ok=False):
         if not self.exists():

--- a/upath/core.py
+++ b/upath/core.py
@@ -123,7 +123,6 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
     _default_accessor = _FSSpecAccessor
 
     def __new__(cls, *args, **kwargs):
-        print("NEW", cls, args, kwargs)
         if issubclass(cls, UPath):
             args_list = list(args)
             url = args_list.pop(0)
@@ -166,7 +165,6 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
             kwargs = dict(**self._kwargs)
         else:
             self._kwargs = dict(**kwargs)
-        print("INIT", kwargs)
         self._url = kwargs.pop("_url") if kwargs.get("_url") else None
 
         if not self._root:
@@ -329,7 +327,6 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         return obj
 
     def __setstate__(self, state):
-        print("SETSTATE", self.__class__.__name__, state)
         kwargs = state["_kwargs"].copy()
         kwargs["_url"] = self._url
         self._kwargs = kwargs
@@ -338,7 +335,6 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         self._init()
 
     def __reduce__(self):
-        print("REDUCE", self.__class__)
         kwargs = self._kwargs.copy()
         kwargs.pop("_url", None)
         return (self.__class__, (self._url.geturl(),), {"_kwargs": kwargs})

--- a/upath/core.py
+++ b/upath/core.py
@@ -280,8 +280,8 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         # can be implemented, but may be tricky
         raise NotImplementedError
 
-    def touch(self, truncate=True, **kwargs):
-        self._accessor.touch(self, truncate=truncate, **kwargs)
+    def touch(self, trunicate=True, **kwargs):
+        self._accessor.touch(self, trunicate=trunicate, **kwargs)
 
     def unlink(self, missing_ok=False):
         if not self.exists():
@@ -327,18 +327,24 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         return obj
 
     def __setstate__(self, state):
+        print("")
+        print("SETSTATE1", self._kwargs, self._root, self._parts)
         kwargs = state["_kwargs"].copy()
         kwargs["_url"] = self._url
         self._kwargs = kwargs
         self._root = state["_root"]
         self._drv = state["_drv"]
+        print("SETSTATE2", self._kwargs, self._root, self._parts)
         # _init needs to be called again, because when __new__ called _init,
         # the _kwargs were not yet set
         self._init()
+        print("SETSTATE3", self._kwargs, self._root, self._parts)
 
     def __reduce__(self):
+        print("")
         kwargs = self._kwargs.copy()
         kwargs.pop("_url", None)
+        print("REDUCE   ", self._kwargs, self._root, self._parts)
         return (
             self.__class__,
             (self._url.geturl(),) + tuple(self._parts),

--- a/upath/core.py
+++ b/upath/core.py
@@ -327,13 +327,22 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         return obj
 
     def __truediv__(self, key):
+        # Add `/` root if not present
         if len(self._parts) == 0:
             key = f"{self._root}{key}"
-        out = self._make_child((key,))
-        kwargs = out._kwargs.copy()
+
+        # Adapted from `PurePath._make_child`
+        drv, root, parts = self._parse_args((key,))
+        drv, root, parts = self._flavour.join_parsed_parts(
+            self._drv, self._root, self._parts, drv, root, parts
+        )
+
+        kwargs = self._kwargs.copy()
         kwargs.pop("_url")
-        out = out.__class__(
-            out._format_parsed_parts(out._drv, out._root, out._parts),
+
+        # Create a new object
+        out = self.__class__(
+            self._format_parsed_parts(drv, root, parts),
             **kwargs,
         )
         return out

--- a/upath/core.py
+++ b/upath/core.py
@@ -337,4 +337,8 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
     def __reduce__(self):
         kwargs = self._kwargs.copy()
         kwargs.pop("_url", None)
-        return (self.__class__, (self._url.geturl(),), {"_kwargs": kwargs})
+        return (
+            self.__class__,
+            (self._url.geturl(),) + tuple(self._parts),
+            {"_kwargs": kwargs},
+        )

--- a/upath/core.py
+++ b/upath/core.py
@@ -344,7 +344,12 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         print("")
         kwargs = self._kwargs.copy()
         kwargs.pop("_url", None)
-        print("REDUCE   ", self._kwargs, self._root, self._parts)
+        print(
+            "REDUCE   ",
+            self._kwargs,
+            self._root,
+            (self._url.geturl(),) + tuple(self._parts),
+        )
         return (
             self.__class__,
             (self._url.geturl(),) + tuple(self._parts),

--- a/upath/core.py
+++ b/upath/core.py
@@ -123,6 +123,7 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
     _default_accessor = _FSSpecAccessor
 
     def __new__(cls, *args, **kwargs):
+        print("NEW", cls, args, kwargs)
         if issubclass(cls, UPath):
             args_list = list(args)
             url = args_list.pop(0)
@@ -165,6 +166,7 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
             kwargs = dict(**self._kwargs)
         else:
             self._kwargs = dict(**kwargs)
+        print("INIT", kwargs)
         self._url = kwargs.pop("_url") if kwargs.get("_url") else None
 
         if not self._root:
@@ -325,3 +327,16 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         if init:
             obj._init(**self._kwargs)
         return obj
+
+    def __setstate__(self, state):
+        print("SETSTATE", self.__class__.__name__, state)
+        kwargs = state["_kwargs"].copy()
+        kwargs["_url"] = self._url
+        self._kwargs = kwargs
+        self._init()
+
+    def __reduce__(self):
+        print("REDUCE", self.__class__)
+        kwargs = self._kwargs.copy()
+        kwargs.pop("_url", None)
+        return (self.__class__, (self._url.geturl(),), {"_kwargs": kwargs})

--- a/upath/core.py
+++ b/upath/core.py
@@ -327,19 +327,16 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         return obj
 
     def __truediv__(self, key):
-        try:
-            if len(self._parts) == 0:
-                key = f"/{key}"
-            out = self._make_child((key,))
-            kwargs = out._kwargs.copy()
-            kwargs.pop("_url")
-            out = out.__class__(
-                out._format_parsed_parts(out._drv, out._root, out._parts),
-                **kwargs,
-            )
-            return out
-        except TypeError:
-            return NotImplemented
+        if len(self._parts) == 0:
+            key = f"{self._root}{key}"
+        out = self._make_child((key,))
+        kwargs = out._kwargs.copy()
+        kwargs.pop("_url")
+        out = out.__class__(
+            out._format_parsed_parts(out._drv, out._root, out._parts),
+            **kwargs,
+        )
+        return out
 
     def __setstate__(self, state):
         kwargs = state["_kwargs"].copy()

--- a/upath/core.py
+++ b/upath/core.py
@@ -330,6 +330,8 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         kwargs = state["_kwargs"].copy()
         kwargs["_url"] = self._url
         self._kwargs = kwargs
+        self._root = state["_root"]
+        self._drv = state["_drv"]
         # _init needs to be called again, because when __new__ called _init,
         # the _kwargs were not yet set
         self._init()
@@ -340,5 +342,5 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         return (
             self.__class__,
             (self._url.geturl(),) + tuple(self._parts),
-            {"_kwargs": kwargs},
+            {"_kwargs": kwargs, "_drv": self._drv, "_root": self._root},
         )

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -234,25 +234,6 @@ class BaseTests:
         pickled_path = pickle.dumps(path)
         recovered_path = pickle.loads(pickled_path)
 
-        print(
-            "ORIGINAL",
-            path,
-            type(path),
-            path._drv,
-            path._root,
-            path._parts,
-            path.fs.storage_options,
-        )
-        print(
-            "RECOVERD",
-            recovered_path,
-            type(recovered_path),
-            recovered_path._drv,
-            recovered_path._root,
-            recovered_path._parts,
-            recovered_path.fs.storage_options,
-        )
-
         assert type(path) == type(recovered_path)
         assert str(path) == str(recovered_path)
         assert path.fs.storage_options == recovered_path.fs.storage_options

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -1,7 +1,7 @@
+import pickle
 from pathlib import Path
 
 import pytest
-
 from upath import UPath
 
 
@@ -228,3 +228,11 @@ class BaseTests:
         upath2 = UPath(p2)
         assert upath2.read_bytes() == content
         upath2.unlink()
+
+    def test_pickling(self):
+        path = self.path
+        pickled_path = pickle.dumps(path)
+        recovered_path = pickle.loads(pickled_path)
+        assert type(path) == type(recovered_path)
+        assert str(path) == str(recovered_path)
+        assert path.fs.storage_options == recovered_path.fs.storage_options

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -233,6 +233,38 @@ class BaseTests:
         path = self.path
         pickled_path = pickle.dumps(path)
         recovered_path = pickle.loads(pickled_path)
+
+        print(
+            path,
+            type(path),
+            str(path),
+            path._drv,
+            path._root,
+            path._parts,
+            path.fs.storage_options,
+        )
+        print(
+            recovered_path,
+            type(recovered_path),
+            str(recovered_path),
+            recovered_path._drv,
+            recovered_path._root,
+            recovered_path._parts,
+            recovered_path.fs.storage_options,
+        )
+
         assert type(path) == type(recovered_path)
         assert str(path) == str(recovered_path)
+        assert path.fs.storage_options == recovered_path.fs.storage_options
+
+    def test_pickling_child_path(self):
+        path = (self.path) / "subfolder" / "subsubfolder"
+        pickled_path = pickle.dumps(path)
+        recovered_path = pickle.loads(pickled_path)
+
+        assert type(path) == type(recovered_path)
+        assert str(path) == str(recovered_path)
+        assert path._drv == recovered_path._drv
+        assert path._root == recovered_path._root
+        assert path._parts == recovered_path._parts
         assert path.fs.storage_options == recovered_path.fs.storage_options

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 from pathlib import Path
 
 import pytest
@@ -37,9 +38,10 @@ class BaseTests:
         mock_glob = list(self.path.glob("**.txt"))
         path_glob = list(pathlib_base.glob("**/*.txt"))
 
-        mock_glob_normalized = sorted([a.path[1:] for a in mock_glob])
+        root = "/" if sys.platform.startswith("win") else ""
+        mock_glob_normalized = sorted([a.path for a in mock_glob])
         path_glob_normalized = sorted(
-            [str(a).replace("\\", "/") for a in path_glob]
+            [f"{root}{a}".replace("\\", "/") for a in path_glob]
         )
 
         assert mock_glob_normalized == path_glob_normalized

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -235,18 +235,18 @@ class BaseTests:
         recovered_path = pickle.loads(pickled_path)
 
         print(
+            "ORIGINAL",
             path,
             type(path),
-            str(path),
             path._drv,
             path._root,
             path._parts,
             path.fs.storage_options,
         )
         print(
+            "RECOVERD",
             recovered_path,
             type(recovered_path),
-            str(recovered_path),
             recovered_path._drv,
             recovered_path._root,
             recovered_path._parts,

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -37,14 +37,12 @@ class BaseTests:
         mock_glob = list(self.path.glob("**.txt"))
         path_glob = list(pathlib_base.glob("**/*.txt"))
 
-        assert len(mock_glob) == len(path_glob)
-        assert all(
-            map(
-                lambda m: m.path
-                in [str(p).replace("\\", "/") for p in path_glob],
-                mock_glob,
-            )
+        mock_glob_normalized = sorted([a.path[1:] for a in mock_glob])
+        path_glob_normalized = sorted(
+            [str(a).replace("\\", "/") for a in path_glob]
         )
+
+        assert mock_glob_normalized == path_glob_normalized
 
     def test_group(self):
         with pytest.raises(NotImplementedError):

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -249,3 +249,13 @@ class BaseTests:
         assert path._root == recovered_path._root
         assert path._parts == recovered_path._parts
         assert path.fs.storage_options == recovered_path.fs.storage_options
+
+    def test_child_path(self):
+        path_a = UPath(f"{self.path}/folder")
+        path_b = self.path / "folder"
+
+        assert str(path_a) == str(path_b)
+        assert path_a._root == path_b._root
+        assert path_a._drv == path_b._drv
+        assert path_a._parts == path_b._parts
+        assert path_a._url == path_b._url

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -146,3 +146,12 @@ def test_pickling():
     assert type(path) == type(recovered_path)
     assert str(path) == str(recovered_path)
     assert path.fs.storage_options == recovered_path.fs.storage_options
+
+
+def test_pickling_child_path():
+    path = UPath("s3://bucket/", storage_options={"anon": True}) / "folder"
+    pickled_path = pickle.dumps(path)
+    recovered_path = pickle.loads(pickled_path)
+    assert type(path) == type(recovered_path)
+    assert str(path) == str(recovered_path)
+    assert path.fs.storage_options == recovered_path.fs.storage_options

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -149,9 +149,12 @@ def test_pickling():
 
 
 def test_pickling_child_path():
-    path = UPath("s3://bucket/", storage_options={"anon": True}) / "folder"
+    path = UPath("s3://bucket", anon=True) / "subfolder" / "subsubfolder"
     pickled_path = pickle.dumps(path)
     recovered_path = pickle.loads(pickled_path)
     assert type(path) == type(recovered_path)
     assert str(path) == str(recovered_path)
+    assert path._drv == recovered_path._drv
+    assert path._root == recovered_path._root
+    assert path._parts == recovered_path._parts
     assert path.fs.storage_options == recovered_path.fs.storage_options

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -140,7 +140,7 @@ def test_create_from_type(path, storage_options, module, object_type):
 
 
 def test_pickling():
-    path = UPath("s3://bucket/folder", storage_options={"anon": True})
+    path = UPath("gcs://bucket/folder", storage_options={"anon": True})
     pickled_path = pickle.dumps(path)
     recovered_path = pickle.loads(pickled_path)
     assert type(path) == type(recovered_path)
@@ -149,7 +149,7 @@ def test_pickling():
 
 
 def test_pickling_child_path():
-    path = UPath("s3://bucket", anon=True) / "subfolder" / "subsubfolder"
+    path = UPath("gcs://bucket", anon=True) / "subfolder" / "subsubfolder"
     pickled_path = pickle.dumps(path)
     recovered_path = pickle.loads(pickled_path)
     assert type(path) == type(recovered_path)

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -1,9 +1,9 @@
-import sys
 import pathlib
+import pickle
+import sys
 import warnings
 
 import pytest
-
 from upath import UPath
 from upath.implementations.s3 import S3Path
 from upath.tests.cases import BaseTests
@@ -137,3 +137,12 @@ def test_create_from_type(path, storage_options, module, object_type):
     except (ImportError, ModuleNotFoundError):
         # fs failed to import
         pass
+
+
+def test_pickling():
+    path = UPath("s3://bucket/folder", storage_options={"anon": True})
+    pickled_path = pickle.dumps(path)
+    recovered_path = pickle.loads(pickled_path)
+    assert type(path) == type(recovered_path)
+    assert str(path) == str(recovered_path)
+    assert path.fs.storage_options == recovered_path.fs.storage_options

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -143,6 +143,7 @@ def test_pickling():
     path = UPath("gcs://bucket/folder", storage_options={"anon": True})
     pickled_path = pickle.dumps(path)
     recovered_path = pickle.loads(pickled_path)
+
     assert type(path) == type(recovered_path)
     assert str(path) == str(recovered_path)
     assert path.fs.storage_options == recovered_path.fs.storage_options
@@ -152,6 +153,7 @@ def test_pickling_child_path():
     path = UPath("gcs://bucket", anon=True) / "subfolder" / "subsubfolder"
     pickled_path = pickle.dumps(path)
     recovered_path = pickle.loads(pickled_path)
+
     assert type(path) == type(recovered_path)
     assert str(path) == str(recovered_path)
     assert path._drv == recovered_path._drv

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -38,7 +38,8 @@ class TestUpath(BaseTests):
     def path(self, local_testdir):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.path = UPath(f"mock:{local_testdir}")
+            root = "/" if sys.platform.startswith("win") else ""
+            self.path = UPath(f"mock:{root}{local_testdir}")
 
     def test_fsspec_compat(self):
         pass

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -38,6 +38,10 @@ class TestUpath(BaseTests):
     def path(self, local_testdir):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+
+            # On Windows the path needs to be prefixed with `/`, becaue
+            # `UPath` implements `_posix_flavour`, which requires a `/` root
+            # in order to correctly deserialize pickled objects
             root = "/" if sys.platform.startswith("win") else ""
             self.path = UPath(f"mock:{root}{local_testdir}")
 
@@ -138,6 +142,17 @@ def test_create_from_type(path, storage_options, module, object_type):
     except (ImportError, ModuleNotFoundError):
         # fs failed to import
         pass
+
+
+def test_child_path():
+    path_a = UPath("gcs://bucket/folder")
+    path_b = UPath("gcs://bucket") / "folder"
+
+    assert str(path_a) == str(path_b)
+    assert path_a._root == path_b._root
+    assert path_a._drv == path_b._drv
+    assert path_a._parts == path_b._parts
+    assert path_a._url == path_b._url
 
 
 def test_pickling():


### PR DESCRIPTION
Currently, pickled instances of `UPath` will be un-pickled as `pathlib.PosixPath`. This PR fixes that by implementing `__reduce__` and `__setstate__` methods.

Fixes #44 