### PR TITLE
adds copy-constructor to UPath

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -123,6 +123,24 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
     _default_accessor = _FSSpecAccessor
 
     def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], cls):
+            other = args[0]
+            new_args = (
+                other._format_parsed_parts(
+                    other._drv, other._root, other._parts
+                ),
+            )
+            new_kwargs = {}
+            if hasattr(other, "_kwargs"):
+                new_kwargs = other._kwargs.copy()
+                new_kwargs.pop("_url", None)
+
+            return cls.__new__(
+                cls,
+                *new_args,
+                **new_kwargs,
+            )
+
         if issubclass(cls, UPath):
             args_list = list(args)
             url = args_list.pop(0)

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -259,3 +259,14 @@ class BaseTests:
         assert path_a._drv == path_b._drv
         assert path_a._parts == path_b._parts
         assert path_a._url == path_b._url
+
+    def test_copy_path(self):
+        path = self.path
+        copy_path = UPath(path)
+
+        assert type(path) == type(copy_path)
+        assert str(path) == str(copy_path)
+        assert path._drv == copy_path._drv
+        assert path._root == copy_path._root
+        assert path._parts == copy_path._parts
+        assert path.fs.storage_options == copy_path.fs.storage_options

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -188,3 +188,14 @@ def test_copy_path():
     assert path._root == copy_path._root
     assert path._parts == copy_path._parts
     assert path.fs.storage_options == copy_path.fs.storage_options
+
+
+def test_copy_path_posix():
+    path = UPath("/tmp/folder", anon=True)
+    copy_path = UPath(path)
+
+    assert type(path) == type(copy_path)
+    assert str(path) == str(copy_path)
+    assert path._drv == copy_path._drv
+    assert path._root == copy_path._root
+    assert path._parts == copy_path._parts

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -191,10 +191,10 @@ def test_copy_path():
 
 
 def test_copy_path_posix():
-    path = UPath("/tmp/folder", anon=True)
+    path = UPath("/tmp/folder")
     copy_path = UPath(path)
 
-    assert type(path) == type(copy_path)
+    assert type(path) == type(copy_path) == pathlib.PosixPath
     assert str(path) == str(copy_path)
     assert path._drv == copy_path._drv
     assert path._root == copy_path._root

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -176,3 +176,15 @@ def test_pickling_child_path():
     assert path._root == recovered_path._root
     assert path._parts == recovered_path._parts
     assert path.fs.storage_options == recovered_path.fs.storage_options
+
+
+def test_copy_path():
+    path = UPath("gcs://bucket/folder", anon=True)
+    copy_path = UPath(path)
+
+    assert type(path) == type(copy_path)
+    assert str(path) == str(copy_path)
+    assert path._drv == copy_path._drv
+    assert path._root == copy_path._root
+    assert path._parts == copy_path._parts
+    assert path.fs.storage_options == copy_path.fs.storage_options


### PR DESCRIPTION
Adds a new capability to the `UPath` constructor for copying `UPath` objects including their attached kwargs.

```python
a = UPath("s3://bucket/folder", key="...", secret="...")
b = UPath(a)

assert b._kwargs["key"] == "..."
```

Fixes #49 