### PR TITLE
Adds default implementations for is_symlink etc.

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -271,6 +271,9 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         return False
 
     def is_symlink(self):
+        info = self._accessor.info(self)
+        if "islink" in info:
+            return info["islink"]
         return False
 
     def is_socket(self):

--- a/upath/core.py
+++ b/upath/core.py
@@ -109,12 +109,6 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         "home",
         "expanduser",
         "group",
-        "is_mount",
-        "is_symlink",
-        "is_socket",
-        "is_fifo",
-        "is_block_device",
-        "is_char_device",
         "lchmod",
         "lstat",
         "owner",
@@ -271,6 +265,24 @@ class UPath(pathlib.Path, PureUPath, metaclass=UPathMeta):
         info = self._accessor.info(self)
         if info["type"] == "file":
             return True
+        return False
+
+    def is_mount(self):
+        return False
+
+    def is_symlink(self):
+        return False
+
+    def is_socket(self):
+        return False
+
+    def is_fifo(self):
+        return False
+
+    def is_block_device(self):
+        return False
+
+    def is_char_device(self):
         return False
 
     def chmod(self, mod):

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -62,22 +62,22 @@ class BaseTests:
         assert not self.path.is_file()
 
     def test_is_mount(self):
-        assert self.path.is_mount() == False
+        assert self.path.is_mount() is False
 
     def test_is_symlink(self):
-        assert self.path.is_symlink() == False
+        assert self.path.is_symlink() is False
 
     def test_is_socket(self):
-        assert self.path.is_socket() == False
+        assert self.path.is_socket() is False
 
     def test_is_fifo(self):
-        assert self.path.is_fifo() == False
+        assert self.path.is_fifo() is False
 
     def test_is_block_device(self):
-        assert self.path.is_block_device() == False
+        assert self.path.is_block_device() is False
 
     def test_is_char_device(self):
-        assert self.path.is_char_device() == False
+        assert self.path.is_char_device() is False
 
     def test_iterdir(self, local_testdir):
         pl_path = Path(local_testdir)

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -62,28 +62,22 @@ class BaseTests:
         assert not self.path.is_file()
 
     def test_is_mount(self):
-        with pytest.raises(NotImplementedError):
-            self.path.is_mount()
+        assert self.path.is_mount() == False
 
     def test_is_symlink(self):
-        with pytest.raises(NotImplementedError):
-            self.path.is_symlink()
+        assert self.path.is_symlink() == False
 
     def test_is_socket(self):
-        with pytest.raises(NotImplementedError):
-            self.path.is_socket()
+        assert self.path.is_socket() == False
 
     def test_is_fifo(self):
-        with pytest.raises(NotImplementedError):
-            self.path.is_fifo()
+        assert self.path.is_fifo() == False
 
     def test_is_block_device(self):
-        with pytest.raises(NotImplementedError):
-            self.path.is_block_device()
+        assert self.path.is_block_device() == False
 
     def test_is_char_device(self):
-        with pytest.raises(NotImplementedError):
-            self.path.is_char_device()
+        assert self.path.is_char_device() == False
 
     def test_iterdir(self, local_testdir):
         pl_path = Path(local_testdir)


### PR DESCRIPTION
This PR adds trivial implementations for several `is_*` methods to `UPath` that all return `False`. Previously, calling these methods would raise a `NotImplementedError`.

```python
a = UPath("s3://bucket/folder", key="...", secret="...")
assert a.is_symlink() is False
```

Fixes #51 