### PR TITLE
Prepare v0.0.13

### DIFF
--- a/upath/__init__.py
+++ b/upath/__init__.py
@@ -1,5 +1,5 @@
 """Pathlib API extended to use fsspec backends"""
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 
 from upath.core import UPath
 

--- a/upath/__init__.py
+++ b/upath/__init__.py
@@ -1,5 +1,5 @@
 """Pathlib API extended to use fsspec backends"""
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 from upath.core import UPath
 


### PR DESCRIPTION
The last release/tag on git didn't trigger a new release on Pypi, because the version number wasn't incremented. You may choose to go to v0.0.14 directly.