### PR TITLE
Change subclassing behavior to Python standard

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -119,7 +119,7 @@ class UPath(pathlib.Path):
                 val = kwargs.get(key)
                 if val:
                     parsed_url = parsed_url._replace(**{key: val})
-            
+
             fsspec_impls = list(registry) + list(known_implementations.keys())
             if parsed_url.scheme and parsed_url.scheme in fsspec_impls:
                 import upath.registry

--- a/upath/core.py
+++ b/upath/core.py
@@ -119,9 +119,9 @@ class UPath(pathlib.Path):
                 val = kwargs.get(key)
                 if val:
                     parsed_url = parsed_url._replace(**{key: val})
-            # treat as local filesystem, return PosixPath or WindowsPath
-            impls = list(registry) + list(known_implementations.keys())
-            if parsed_url.scheme and parsed_url.scheme in impls:
+            
+            fsspec_impls = list(registry) + list(known_implementations.keys())
+            if parsed_url.scheme and parsed_url.scheme in fsspec_impls:
                 import upath.registry
 
                 cls = upath.registry._registry[parsed_url.scheme]
@@ -129,6 +129,7 @@ class UPath(pathlib.Path):
                 args_list.insert(0, parsed_url.path)
                 args = tuple(args_list)
                 return cls._from_parts(args, **kwargs)
+        # treat as local filesystem, return PosixPath or WindowsPath
         return pathlib.Path(*args, **kwargs)
 
     def __getattr__(self, item):

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -7,7 +7,7 @@ from upath.errors import NotDirectoryError
 from upath.tests.cases import BaseTests
 
 
-@pytest.mark.skipif(not sys.platform == "linux", reason="Only linux")
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows bad")
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
     @pytest.fixture(autouse=True, scope="function")

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -7,7 +7,7 @@ from upath.errors import NotDirectoryError
 from upath.tests.cases import BaseTests
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows bad")
+@pytest.mark.skipif(not sys.platform == "linux", reason="Only linux")
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
     @pytest.fixture(autouse=True, scope="function")

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -224,6 +224,11 @@ def test_copy_path_append():
 
     assert str(path / "folder2" / "folder3") == str(copy_path)
 
+    path = UPath("/tmp/folder")
+    copy_path = UPath(path, "folder2", "folder3")
+
+    assert str(path / "folder2" / "folder3") == str(copy_path)
+
 
 def test_copy_path_append_kwargs():
     path = UPath("gcs://bucket/folder", anon=True)

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -14,7 +14,6 @@ from upath.tests.cases import BaseTests
     reason="don't run test on Windows",
 )
 def test_posix_path(local_testdir):
-    print(type(UPath(local_testdir)))
     assert isinstance(UPath(local_testdir), pathlib.PosixPath)
 
 
@@ -190,8 +189,6 @@ def test_pickling_child_path():
 def test_copy_path():
     path = UPath("gcs://bucket/folder", anon=True)
     copy_path = UPath(path)
-
-    print(type(path), type(copy_path))
 
     assert type(path) == type(copy_path)
     assert str(path) == str(copy_path)

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -81,11 +81,18 @@ def test_subclass(local_testdir):
     assert isinstance(path, pathlib.Path)
 
 
+def test_subclass_with_gcs():
+    path = UPath("gcs://bucket", anon=True)
+    assert isinstance(path, UPath)
+    assert isinstance(path, pathlib.Path)
+
+
 def test_instance_check(local_testdir):
     path = pathlib.Path(local_testdir)
     upath = UPath(local_testdir)
     # test instance check passes
-    assert isinstance(upath, UPath)
+    assert isinstance(upath, pathlib.Path)
+    assert not isinstance(upath, UPath)
     # test type is same as pathlib
     assert type(upath) is type(path)
     upath = UPath(f"file://{local_testdir}")
@@ -97,6 +104,7 @@ def test_new_method(local_testdir):
     path = UPath.__new__(pathlib.Path, local_testdir)
     assert str(path) == str(pathlib.Path(local_testdir))
     assert isinstance(path, pathlib.Path)
+    assert not isinstance(path, UPath)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
The current implementation makes it very hard to discern objects of `pathlib.Path` from objects of `UPath` (and its subclasses). 
```python
upath = UPath("gcs://bucket")
path = pathlib.Path("/tmp")

assert isinstance(upath, UPath)  # true, which is expected
assert isinstance(upath, pathlib.Path)  # also true, which is expected, because UPath is a subclass of pathlib.Path

assert isinstance(path, pathlib.Path)  # true, which is expected
assert isinstance(path, UPath) # also true, but NOT expected
```
This is due to the fact that `UPath` overwrites `isinstance` and `issubclass` checks in a meta class.

In my user code, I currently discern between the two based on the existence of the `_kwargs` attribute.
```python
if hasattr(path, "_kwargs"):
    upath = cast(UPath, path)
    ...
```

I think the current behavior is surprising and not very pythonic.

In this PR, I remove the multi-subclassing of `UPath`. This was unneccassary, because `_flavour` can be implemented directly in `UPath` and `pathlib.Path` is a subclass of `pathlib.PurePath` itself. With that, I could also remove the meta classes.
This PR also makes `upath` play more nicely with type checkers such as `mypy` or `pylance`.