### PR TITLE
Fix iterdir for http-path and refactorings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,9 @@ def install(session):
 
 @nox.session(python=False)
 def smoke(session):
-    session.install(*"pytest aiohttp requests gcsfs".split())
+    session.install(
+        *"pytest aiohttp requests gcsfs s3fs moto[s3,server]".split()
+    )
     session.run(*"pytest --skiphdfs -vv upath".split())
 
 

--- a/upath/core.py
+++ b/upath/core.py
@@ -431,15 +431,11 @@ class UPath(pathlib.Path):
         return out
 
     def __setstate__(self, state):
-        kwargs = state["_kwargs"].copy()
-        self._kwargs = kwargs
-        self._url = state["_url"]
+        self._kwargs = state["_kwargs"].copy()
 
     def __reduce__(self):
-        kwargs = self._kwargs.copy()
-
         return (
             self.__class__,
             (self._format_parsed_parts(self._drv, self._root, self._parts),),
-            {"_kwargs": kwargs, "_url": self._url},
+            {"_kwargs": self._kwargs.copy()},
         )

--- a/upath/core.py
+++ b/upath/core.py
@@ -34,7 +34,7 @@ class _FSSpecAccessor:
 
         def wrapper(*args, **kwargs):
             args, kwargs = self._transform_arg_paths(args, kwargs)
-            print(args, kwargs)
+            print(func, args, kwargs)
             return func(*args, **kwargs)
 
         return wrapper

--- a/upath/core.py
+++ b/upath/core.py
@@ -177,6 +177,7 @@ class UPath(pathlib.Path):
         )
 
     def _format_parsed_parts(self, drv, root, parts):
+        # breakpoint()
         if parts:
             join_parts = parts[1:] if parts[0] == "/" else parts
         else:
@@ -238,6 +239,7 @@ class UPath(pathlib.Path):
                 self._raise_closed()
 
     def glob(self, pattern):
+        # breakpoint()
         path = self.joinpath(pattern)
         for name in self._accessor.glob(self, path=path.path):
             name = self._sub_path(name)
@@ -329,6 +331,7 @@ class UPath(pathlib.Path):
 
     @classmethod
     def _from_parts(cls, args, **kwargs):
+        # breakpoint()
         obj = object.__new__(cls)
         drv, root, parts = obj._parse_args(args, **kwargs)
         obj._drv = drv

--- a/upath/core.py
+++ b/upath/core.py
@@ -359,9 +359,11 @@ class UPath(pathlib.Path):
             if not parts:
                 root = "/"
             elif parts[0] == "/":
-                root = parts.pop(0)
-        obj._root = root
+                root = parts[0]
+        if len(obj._parts) == 0 or obj._parts[0] != root:
+            obj._parts.insert(0, root)
 
+        obj._root = root
         return obj
 
     @property

--- a/upath/core.py
+++ b/upath/core.py
@@ -92,7 +92,8 @@ class UPath(pathlib.Path):
     __slots__ = (
         "_url",
         "_kwargs",
-    )  # `_accessor` is inherited from `pathlib.Path`
+        "_accessor",  # overwritten because of default in Python 3.10
+    )
     _flavour = pathlib._posix_flavour
     _default_accessor = _FSSpecAccessor
 
@@ -137,8 +138,10 @@ class UPath(pathlib.Path):
     def __getattr__(self, item):
         if item == "_accessor":
             # cache the _accessor attribute on first access
-            kw = self._kwargs.copy()
-            self._accessor = _accessor = self._default_accessor(self._url, **kw)
+            kwargs = self._kwargs.copy()
+            self._accessor = _accessor = self._default_accessor(
+                self._url, **kwargs
+            )
             return _accessor
         else:
             raise AttributeError(item)

--- a/upath/core.py
+++ b/upath/core.py
@@ -34,7 +34,6 @@ class _FSSpecAccessor:
 
         def wrapper(*args, **kwargs):
             args, kwargs = self._transform_arg_paths(args, kwargs)
-            print(func, args, kwargs)
             return func(*args, **kwargs)
 
         return wrapper

--- a/upath/core.py
+++ b/upath/core.py
@@ -274,24 +274,33 @@ class UPath(pathlib.Path):
             return self._accessor.exists(self)
 
     def is_dir(self):
-        info = self._accessor.info(self)
-        if info["type"] == "directory":
-            return True
+        try:
+            info = self._accessor.info(self)
+            if info["type"] == "directory":
+                return True
+        except FileNotFoundError:
+            return False
         return False
 
     def is_file(self):
-        info = self._accessor.info(self)
-        if info["type"] == "file":
-            return True
+        try:
+            info = self._accessor.info(self)
+            if info["type"] == "file":
+                return True
+        except FileNotFoundError:
+            return False
         return False
 
     def is_mount(self):
         return False
 
     def is_symlink(self):
-        info = self._accessor.info(self)
-        if "islink" in info:
-            return info["islink"]
+        try:
+            info = self._accessor.info(self)
+            if "islink" in info:
+                return info["islink"]
+        except FileNotFoundError:
+            return False
         return False
 
     def is_socket(self):

--- a/upath/core.py
+++ b/upath/core.py
@@ -34,6 +34,7 @@ class _FSSpecAccessor:
 
         def wrapper(*args, **kwargs):
             args, kwargs = self._transform_arg_paths(args, kwargs)
+            print(args, kwargs)
             return func(*args, **kwargs)
 
         return wrapper

--- a/upath/core.py
+++ b/upath/core.py
@@ -249,7 +249,6 @@ class UPath(pathlib.Path):
         return output
 
     def glob(self, pattern):
-        # breakpoint()
         path = self.joinpath(pattern)
         for name in self._accessor.glob(self, path=path.path):
             name = self._sub_path(name)
@@ -341,7 +340,6 @@ class UPath(pathlib.Path):
 
     @classmethod
     def _from_parts(cls, args, **kwargs):
-        # breakpoint()
         obj = object.__new__(cls)
         drv, root, parts = obj._parse_args(args, **kwargs)
         obj._drv = drv

--- a/upath/core.py
+++ b/upath/core.py
@@ -362,7 +362,7 @@ class UPath(pathlib.Path):
             if not parts:
                 root = "/"
             elif parts[0] == "/":
-                root = parts[0]
+                root = parts.pop(0)
         if len(obj._parts) == 0 or obj._parts[0] != root:
             obj._parts.insert(0, root)
 

--- a/upath/core.py
+++ b/upath/core.py
@@ -368,7 +368,6 @@ class UPath(pathlib.Path):
     def _from_parts(cls, args, url=None, **kwargs):
         obj = object.__new__(cls)
         drv, root, parts = obj._parse_args(args)
-        kwargs = kwargs.copy()
         obj._drv = drv
         if sys.version_info < (3, 9):
             obj._closed = False

--- a/upath/implementations/gcs.py
+++ b/upath/implementations/gcs.py
@@ -35,9 +35,10 @@ class GCSPath(upath.core.UPath):
         return obj
 
     def _sub_path(self, name):
-        """gcs returns path as `{bucket}/<path>` with listdir
-        and glob, so here we can add the netloc to the sub string
-        so it gets subbed out as well
+        """
+        `gcsfs` returns the full path as `<bucket>/<path>` with `listdir` and
+        `glob`. However, in `iterdir` and `glob` we only want the relative path
+        to `self`.
         """
         sp = self.path
         subed = re.sub(f"^({self._url.netloc})?/?({sp}|{sp[1:]})/?", "", name)

--- a/upath/implementations/gcs.py
+++ b/upath/implementations/gcs.py
@@ -1,5 +1,4 @@
 import upath.core
-import os
 import re
 
 
@@ -11,7 +10,7 @@ class _GCSAccessor(upath.core._FSSpecAccessor):
         """
         netloc has already been set to project via `GCSPath._from_parts`
         """
-        s = os.path.join(self._url.netloc, s.lstrip("/"))
+        s = f"{self._url.netloc}/{s.lstrip('/')}"
         return s
 
 

--- a/upath/implementations/gcs.py
+++ b/upath/implementations/gcs.py
@@ -19,19 +19,19 @@ class GCSPath(upath.core.UPath):
     _default_accessor = _GCSAccessor
 
     @classmethod
-    def _from_parts(cls, args, **kwargs):
-        obj = super()._from_parts(args, **kwargs)
-        if kwargs.get("bucket") and kwargs.get("_url"):
-            bucket = obj._kwargs.pop("bucket")
-            obj._url = obj._url._replace(netloc=bucket)
+    def _from_parts(cls, args, url=None, **kwargs):
+        if kwargs.get("bucket") and url is not None:
+            bucket = kwargs.pop("bucket")
+            url = url._replace(netloc=bucket)
+        obj = super()._from_parts(args, url, **kwargs)
         return obj
 
     @classmethod
-    def _from_parsed_parts(cls, drv, root, parts, **kwargs):
-        obj = super()._from_parsed_parts(drv, root, parts, **kwargs)
-        if kwargs.get("bucket") and kwargs.get("_url"):
-            bucket = obj._kwargs.pop("bucket")
-            obj._url = obj._url._replace(netloc=bucket)
+    def _from_parsed_parts(cls, drv, root, parts, url=None, **kwargs):
+        if kwargs.get("bucket") and url is not None:
+            bucket = kwargs.pop("bucket")
+            url = url._replace(netloc=bucket)
+        obj = super()._from_parsed_parts(drv, root, parts, url, **kwargs)
         return obj
 
     def _sub_path(self, name):

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -1,3 +1,4 @@
+import re
 import urllib
 
 import upath.core

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -1,4 +1,3 @@
-import re
 import urllib
 
 import upath.core
@@ -45,4 +44,11 @@ class HTTPPath(upath.core.UPath):
         sp = self.path
         complete_address = self._format_parsed_parts(None, None, [sp])
 
-        return re.sub(f"^({complete_address}|{sp[1:]}|{sp})/", "", name)
+        if name.startswith(complete_address):
+            name = name[len(complete_address):]
+        if name.startswith("/"):
+            name = name[1:]
+        if name.endswith("/"):
+            name = name[:-1]
+
+        return name

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -35,10 +35,16 @@ class HTTPPath(upath.core.UPath):
     _default_accessor = _HTTPAccessor
 
     def is_dir(self):
-        return self._path_type() == "directory"
+        try:
+            return self._path_type() == "directory"
+        except FileNotFoundError:
+            return False
 
     def is_file(self):
-        return self._path_type() == "file"
+        try:
+            return self._path_type() == "file"
+        except FileNotFoundError:
+            return False
 
     def _path_type(self):
         info = self._accessor.info(self)

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -23,8 +23,8 @@ class _HTTPAccessor(upath.core._FSSpecAccessor):
                         args.insert(0, first_arg)
                     args = tuple(args)
                 else:
-                    new_url = self._url.replace(path=kwargs["path"])
-                    unparsed = urllib.urlunparse(new_url)
+                    new_url = self._url._replace(path=kwargs["path"])
+                    unparsed = urllib.parse.urlunparse(new_url)
                     kwargs["path"] = unparsed
             return func(*args, **kwargs)
 
@@ -35,7 +35,19 @@ class HTTPPath(upath.core.UPath):
     _default_accessor = _HTTPAccessor
 
     def is_dir(self):
-        return super().is_dir() or next(self.iterdir(), None) is not None
+        return self._path_type() == "directory"
+
+    def is_file(self):
+        return self._path_type() == "file"
+
+    def _path_type(self):
+        info = self._accessor.info(self)
+        if (
+            info["type"] == "directory"
+            or next(self.iterdir(), None) is not None
+        ):
+            return "directory"
+        return "file"
 
     def _sub_path(self, name):
         """fsspec returns path as `scheme://netloc/<path>` with listdir
@@ -45,7 +57,7 @@ class HTTPPath(upath.core.UPath):
         complete_address = self._format_parsed_parts(None, None, [sp])
 
         if name.startswith(complete_address):
-            name = name[len(complete_address):]
+            name = name[len(complete_address) :]  # noqa: E203
         if name.startswith("/"):
             name = name[1:]
         if name.endswith("/"):

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -33,3 +33,13 @@ class _HTTPAccessor(upath.core._FSSpecAccessor):
 
 class HTTPPath(upath.core.UPath):
     _default_accessor = _HTTPAccessor
+
+
+    def _sub_path(self, name):
+        """fsspec returns path as `scheme://netloc/<path>` with listdir
+        and glob, so we potentially need to sub the whole string
+        """
+        sp = self.path
+        complete_address = self._format_parsed_parts(None, None, [sp])
+
+        return re.sub(f"^({complete_address}|{sp[1:]}|{sp})/", "", name)

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -35,6 +35,8 @@ class _HTTPAccessor(upath.core._FSSpecAccessor):
 class HTTPPath(upath.core.UPath):
     _default_accessor = _HTTPAccessor
 
+    def is_dir(self):
+        return super().is_dir() or next(self.iterdir(), None) is not None
 
     def _sub_path(self, name):
         """fsspec returns path as `scheme://netloc/<path>` with listdir

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -58,9 +58,6 @@ class HTTPPath(upath.core.UPath):
 
         if name.startswith(complete_address):
             name = name[len(complete_address) :]  # noqa: E203
-        if name.startswith("/"):
-            name = name[1:]
-        if name.endswith("/"):
-            name = name[:-1]
+        name = name.strip("/")
 
         return name

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -56,11 +56,12 @@ class HTTPPath(upath.core.UPath):
         return "file"
 
     def _sub_path(self, name):
-        """fsspec returns path as `scheme://netloc/<path>` with listdir
-        and glob, so we potentially need to sub the whole string
         """
-        sp = self.path
-        complete_address = self._format_parsed_parts(None, None, [sp])
+        `fsspec` returns the full path as `scheme://netloc/<path>` with
+        `listdir` and `glob`. However, in `iterdir` and `glob` we only want the
+        relative path to `self`.
+        """
+        complete_address = self._format_parsed_parts(None, None, [self.path])
 
         if name.startswith(complete_address):
             name = name[len(complete_address) :]  # noqa: E203

--- a/upath/implementations/memory.py
+++ b/upath/implementations/memory.py
@@ -6,12 +6,6 @@ class _MemoryAccessor(upath.core._FSSpecAccessor):
         super().__init__(*args, **kwargs)
         self._fs.root_marker = ""
 
-    def _format_path(self, s):
-        """If the filesystem backend doesn't have a root_marker, strip the
-        leading slash of a path
-        """
-        return s
-
 
 class MemoryPath(upath.core.UPath):
     _default_accessor = _MemoryAccessor

--- a/upath/implementations/memory.py
+++ b/upath/implementations/memory.py
@@ -14,8 +14,6 @@ class MemoryPath(upath.core.UPath):
         """Iterate over the files in this directory.  Does not yield any
         result for the special paths '.' and '..'.
         """
-        if self._closed:
-            self._raise_closed()
         for name in self._accessor.listdir(self):
             # fsspec returns dictionaries
             if isinstance(name, dict):
@@ -27,5 +25,3 @@ class MemoryPath(upath.core.UPath):
             name = name.rstrip("/")
             name = self._sub_path(name)
             yield self._make_child_relpath(name)
-            if self._closed:
-                self._raise_closed()

--- a/upath/implementations/s3.py
+++ b/upath/implementations/s3.py
@@ -36,9 +36,10 @@ class S3Path(upath.core.UPath):
         return obj
 
     def _sub_path(self, name):
-        """s3fs returns path as `{bucket}/<path>` with listdir
-        and glob, so here we can add the netloc to the sub string
-        so it gets subbed out as well
+        """
+        `s3fs` returns the full path as `<bucket>/<path>` with `listdir` and
+        `glob`. However, in `iterdir` and `glob` we only want the relative path
+        to `self`.
         """
         sp = self.path
         subed = re.sub(f"^({self._url.netloc})?/?({sp}|{sp[1:]})/?", "", name)

--- a/upath/implementations/s3.py
+++ b/upath/implementations/s3.py
@@ -19,19 +19,20 @@ class S3Path(upath.core.UPath):
     _default_accessor = _S3Accessor
 
     @classmethod
-    def _from_parts(cls, args, **kwargs):
-        obj = super()._from_parts(args, **kwargs)
-        if kwargs.get("bucket") and kwargs.get("_url"):
-            bucket = obj._kwargs.pop("bucket")
-            obj._url = obj._url._replace(netloc=bucket)
+    def _from_parts(cls, args, url=None, **kwargs):
+        if kwargs.get("bucket") and url is not None:
+            bucket = kwargs.pop("bucket")
+            url = url._replace(netloc=bucket)
+        obj = super()._from_parts(args, url, **kwargs)
         return obj
 
     @classmethod
-    def _from_parsed_parts(cls, drv, root, parts, **kwargs):
-        obj = super()._from_parsed_parts(drv, root, parts, **kwargs)
-        if kwargs.get("bucket") and kwargs.get("_url"):
-            bucket = obj._kwargs.pop("bucket")
-            obj._url = obj._url._replace(netloc=bucket)
+    def _from_parsed_parts(cls, drv, root, parts, url=None, **kwargs):
+        if kwargs.get("bucket") and url is not None:
+            bucket = kwargs.pop("bucket")
+            url = url._replace(netloc=bucket)
+
+        obj = super()._from_parsed_parts(drv, root, parts, url, **kwargs)
         return obj
 
     def _sub_path(self, name):

--- a/upath/implementations/s3.py
+++ b/upath/implementations/s3.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 import upath.core
@@ -12,7 +11,7 @@ class _S3Accessor(upath.core._FSSpecAccessor):
         """If the filesystem backend doesn't have a root_marker, strip the
         leading slash of a path and add the bucket
         """
-        s = os.path.join(self._url.netloc, s.lstrip("/"))
+        s = f"{self._url.netloc}/{s.lstrip('/')}"
         return s
 
 

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -1,22 +1,27 @@
+from typing import Dict, Type
 import warnings
 
 import upath
+from upath.core import UPath
 
 
 class _Registry:
     from upath.implementations import hdfs, http, memory, s3, gcs
 
-    http = http.HTTPPath
-    hdfs = hdfs.HDFSPath
-    s3a = s3.S3Path
-    s3 = s3.S3Path
-    memory = memory.MemoryPath
-    gs = gcs.GCSPath
-    gcs = gcs.GCSPath
+    known_implementations: Dict[str, Type[UPath]] = {
+        "https": http.HTTPPath,
+        "http": http.HTTPPath,
+        "hdfs": hdfs.HDFSPath,
+        "s3a": s3.S3Path,
+        "s3": s3.S3Path,
+        "memory": memory.MemoryPath,
+        "gs": gcs.GCSPath,
+        "gcs": gcs.GCSPath,
+    }
 
     def __getitem__(self, item):
-        implemented_path = getattr(self, item, None)
-        if not implemented_path:
+        implementation = self.known_implementations.get(item, None)
+        if not implementation:
             warning_str = (
                 f"{item} filesystem path not explicitly implemented. "
                 "falling back to default implementation. "
@@ -24,7 +29,7 @@ class _Registry:
             )
             warnings.warn(warning_str, UserWarning)
             return upath.UPath
-        return implemented_path
+        return implementation
 
 
 _registry = _Registry()

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -51,6 +51,7 @@ class BaseTests:
             self.path.group()
 
     def test_is_dir(self):
+        print(self.path.stat())
         assert self.path.is_dir()
 
         path = self.path.joinpath("file1.txt")
@@ -58,6 +59,7 @@ class BaseTests:
 
     def test_is_file(self):
         path = self.path.joinpath("file1.txt")
+        print(path.stat())
         assert path.is_file()
         assert not self.path.is_file()
 
@@ -89,8 +91,22 @@ class BaseTests:
             assert x.exists()
 
         assert len(up_iter) == len(pl_iter)
-        pnames = [p.name for p in pl_iter]
-        assert all(map(lambda x: x.name in pnames, up_iter))
+        print(set(p.name for p in pl_iter), set(u.name for u in up_iter))
+        assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
+        assert next(self.path.parent.iterdir()).exists()
+
+    def test_iterdir2(self, local_testdir):
+        pl_path = Path(local_testdir) / "folder1"
+
+        up_iter = list((self.path / "folder1").iterdir())
+        pl_iter = list(pl_path.iterdir())
+
+        for x in up_iter:
+            assert x.exists()
+
+        assert len(up_iter) == len(pl_iter)
+        print(set(p.name for p in pl_iter), set(u.name for u in up_iter))
+        assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
 
     def test_lchmod(self):
@@ -248,6 +264,7 @@ class BaseTests:
         path_a = UPath(f"{self.path}/folder")
         path_b = self.path / "folder"
 
+        print(str(path_a), str(path_b))
         assert str(path_a) == str(path_b)
         assert path_a._root == path_b._root
         assert path_a._drv == path_b._drv
@@ -262,5 +279,6 @@ class BaseTests:
         assert str(path) == str(copy_path)
         assert path._drv == copy_path._drv
         assert path._root == copy_path._root
+        print(path._parts, copy_path._parts)
         assert path._parts == copy_path._parts
         assert path.fs.storage_options == copy_path.fs.storage_options

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -56,13 +56,16 @@ class BaseTests:
     def test_is_dir(self):
         assert self.path.is_dir()
 
-        path = self.path.joinpath("file1.txt")
+        path = self.path / "file1.txt"
         assert not path.is_dir()
+        assert not (self.path / "not-existing-dir").is_dir()
 
     def test_is_file(self):
-        path = self.path.joinpath("file1.txt")
+        path = self.path / "file1.txt"
         assert path.is_file()
         assert not self.path.is_file()
+
+        assert not (self.path / "not-existing-file.txt").is_file()
 
     def test_is_mount(self):
         assert self.path.is_mount() is False

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -266,9 +266,7 @@ class BaseTests:
         assert path.fs.storage_options == recovered_path.fs.storage_options
 
     def test_child_path(self):
-        path_str = str(self.path)
-        if path_str.endswith("/"):
-            path_str = path_str[:-1]
+        path_str = str(self.path).rstrip("/")
         path_a = UPath(f"{path_str}/folder")
         path_b = self.path / "folder"
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -1,5 +1,4 @@
 import pickle
-import sys
 from pathlib import Path
 
 import pytest
@@ -38,10 +37,14 @@ class BaseTests:
         mock_glob = list(self.path.glob("**.txt"))
         path_glob = list(pathlib_base.glob("**/*.txt"))
 
-        root = "/" if sys.platform.startswith("win") else ""
-        mock_glob_normalized = sorted([a.path for a in mock_glob])
+        mock_glob_normalized = sorted(
+            [a.relative_to(self.path).path for a in mock_glob]
+        )
         path_glob_normalized = sorted(
-            [f"{root}{a}".replace("\\", "/") for a in path_glob]
+            [
+                f"/{a.relative_to(pathlib_base)}".replace("\\", "/")
+                for a in path_glob
+            ]
         )
 
         assert mock_glob_normalized == path_glob_normalized
@@ -278,6 +281,7 @@ class BaseTests:
         assert str(path) == str(copy_path)
         assert path._drv == copy_path._drv
         assert path._root == copy_path._root
+        print(str(path), str(copy_path))
         print(path._parts, copy_path._parts)
         assert path._parts == copy_path._parts
         assert path.fs.storage_options == copy_path.fs.storage_options

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -88,10 +88,10 @@ class BaseTests:
         pl_iter = list(pl_path.iterdir())
 
         for x in up_iter:
+            assert x.name != ""
             assert x.exists()
 
         assert len(up_iter) == len(pl_iter)
-        print(set(p.name for p in pl_iter), set(u.name for u in up_iter))
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
 
@@ -105,7 +105,6 @@ class BaseTests:
             assert x.exists()
 
         assert len(up_iter) == len(pl_iter)
-        print(set(p.name for p in pl_iter), set(u.name for u in up_iter))
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -47,7 +47,6 @@ class BaseTests:
             [f"/{posixify(a.relative_to(pathlib_base))}" for a in path_glob]
         )
 
-        print(mock_glob_normalized, path_glob_normalized)
         assert mock_glob_normalized == path_glob_normalized
 
     def test_group(self):
@@ -93,7 +92,6 @@ class BaseTests:
             assert x.name != ""
             assert x.exists()
 
-        print(up_iter, pl_iter)
         assert len(up_iter) == len(pl_iter)
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
@@ -107,7 +105,6 @@ class BaseTests:
         for x in up_iter:
             assert x.exists()
 
-        print(up_iter, pl_iter)
         assert len(up_iter) == len(pl_iter)
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
@@ -233,6 +230,7 @@ class BaseTests:
         upath1 = self.path / "output1.csv"
         p1 = strip_scheme(upath1)
         upath1.write_bytes(content)
+        print(p1, upath1)
         assert fs is upath1.fs
         with fs.open(p1) as f:
             assert f.read() == content
@@ -275,7 +273,6 @@ class BaseTests:
         path_a = UPath(f"{path_str}/folder")
         path_b = self.path / "folder"
 
-        print(str(path_a), str(path_b))
         assert str(path_a) == str(path_b)
         assert path_a._root == path_b._root
         assert path_a._drv == path_b._drv
@@ -290,7 +287,5 @@ class BaseTests:
         assert str(path) == str(copy_path)
         assert path._drv == copy_path._drv
         assert path._root == copy_path._root
-        print(str(path), str(copy_path))
-        print(path._parts, copy_path._parts)
         assert path._parts == copy_path._parts
         assert path.fs.storage_options == copy_path.fs.storage_options

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -224,8 +224,11 @@ class BaseTests:
         scheme = self.path._url.scheme
         content = b"a,b,c\n1,2,3\n4,5,6"
 
+        if not fs.exists(f"{scheme}://tmp"):
+            fs.mkdir(f"{scheme}://tmp")
+
         p1 = f"{scheme}:///tmp/output1.csv"
-        upath1 = UPath(p1)
+        upath1 = UPath(p1, **self.path._kwargs)
         upath1.write_bytes(content)
         with fs.open(p1) as f:
             assert f.read() == content
@@ -235,7 +238,7 @@ class BaseTests:
         p2 = f"{scheme}:///tmp/output2.csv"
         with fs.open(p2, "wb") as f:
             f.write(content)
-        upath2 = UPath(p2)
+        upath2 = UPath(p2, **self.path._kwargs)
         assert upath2.read_bytes() == content
         upath2.unlink()
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -47,6 +47,7 @@ class BaseTests:
             [f"/{posixify(a.relative_to(pathlib_base))}" for a in path_glob]
         )
 
+        print(mock_glob_normalized, path_glob_normalized)
         assert mock_glob_normalized == path_glob_normalized
 
     def test_group(self):
@@ -92,6 +93,7 @@ class BaseTests:
             assert x.name != ""
             assert x.exists()
 
+        print(up_iter, pl_iter)
         assert len(up_iter) == len(pl_iter)
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
@@ -105,6 +107,7 @@ class BaseTests:
         for x in up_iter:
             assert x.exists()
 
+        print(up_iter, pl_iter)
         assert len(up_iter) == len(pl_iter)
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from upath import UPath
+from .utils import posixify
 
 
 class BaseTests:
@@ -41,10 +42,7 @@ class BaseTests:
             [a.relative_to(self.path).path for a in mock_glob]
         )
         path_glob_normalized = sorted(
-            [
-                f"/{a.relative_to(pathlib_base)}".replace("\\", "/")
-                for a in path_glob
-            ]
+            [f"/{posixify(a.relative_to(pathlib_base))}" for a in path_glob]
         )
 
         assert mock_glob_normalized == path_glob_normalized
@@ -263,7 +261,10 @@ class BaseTests:
         assert path.fs.storage_options == recovered_path.fs.storage_options
 
     def test_child_path(self):
-        path_a = UPath(f"{self.path}/folder")
+        path_str = str(self.path)
+        if path_str.endswith("/"):
+            path_str = path_str[:-1]
+        path_a = UPath(f"{path_str}/folder")
         path_b = self.path / "folder"
 
         print(str(path_a), str(path_b))

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -1,6 +1,7 @@
 import pickle
 from pathlib import Path
 import re
+import sys
 
 import pytest
 from upath import UPath
@@ -223,7 +224,8 @@ class BaseTests:
         content = b"a,b,c\n1,2,3\n4,5,6"
 
         def strip_scheme(path):
-            return "/" + re.sub("^[a-z0-9]+:/+", "", str(path))
+            root = "" if sys.platform.startswith("win") else "/"
+            return root + re.sub("^[a-z0-9]+:/+", "", str(path))
 
         upath1 = self.path / "output1.csv"
         p1 = strip_scheme(upath1)

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -230,7 +230,6 @@ class BaseTests:
         upath1 = self.path / "output1.csv"
         p1 = strip_scheme(upath1)
         upath1.write_bytes(content)
-        print(p1, upath1)
         assert fs is upath1.fs
         with fs.open(p1) as f:
             assert f.read() == content

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -225,7 +225,7 @@ class BaseTests:
 
         def strip_scheme(path):
             root = "" if sys.platform.startswith("win") else "/"
-            return root + re.sub("^[a-z0-9]+:/+", "", str(path))
+            return root + re.sub("^[a-z0-9]+:/*", "", str(path))
 
         upath1 = self.path / "output1.csv"
         p1 = strip_scheme(upath1)

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -188,7 +188,7 @@ def s3_fixture(s3_server, local_testdir):
             for key in keys:
                 s3.rm(f"{dir}/{key}")
     else:
-        s3.mkdir(bucket_name, create_parents=True)
+        s3.makedirs(bucket_name)
     for x in Path(local_testdir).glob("**/*"):
         target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
         if x.is_file():
@@ -255,7 +255,7 @@ def gcs_fixture(docker_gcs, local_testdir):
             for key in keys:
                 gcs.rm(f"{dir}/{key}")
     else:
-        gcs.mkdir(bucket_name, create_parents=True)
+        gcs.makedirs(bucket_name)
     for x in Path(local_testdir).glob("**/*"):
         target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
         if x.is_file():

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -13,6 +13,8 @@ from fsspec.registry import register_implementation, _registry
 
 import fsspec
 
+from .utils import posixify
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -190,7 +192,7 @@ def s3_fixture(s3_server, local_testdir):
     else:
         s3.mkdir(bucket_name)
     for x in Path(local_testdir).glob("**/*"):
-        target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
+        target_path = f"{bucket_name}/{posixify(x.relative_to(local_testdir))}"
         if x.is_file():
             s3.upload(str(x), target_path)
     s3.invalidate_cache()
@@ -250,7 +252,7 @@ def gcs_fixture(docker_gcs, local_testdir):
     else:
         gcs.mkdir(bucket_name)
     for x in Path(local_testdir).glob("**/*"):
-        target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
+        target_path = f"{bucket_name}/{posixify(x.relative_to(local_testdir))}"
         if x.is_file():
             gcs.upload(str(x), target_path)
     gcs.invalidate_cache()

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -188,7 +188,7 @@ def s3_fixture(s3_server, local_testdir):
             for key in keys:
                 s3.rm(f"{dir}/{key}")
     else:
-        s3.makedirs(bucket_name)
+        s3.mkdir(bucket_name)
     for x in Path(local_testdir).glob("**/*"):
         target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
         if x.is_file():
@@ -255,11 +255,13 @@ def gcs_fixture(docker_gcs, local_testdir):
             for key in keys:
                 gcs.rm(f"{dir}/{key}")
     else:
-        gcs.makedirs(bucket_name)
+        gcs.mkdir(bucket_name)
     for x in Path(local_testdir).glob("**/*"):
         target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
         if x.is_file():
             gcs.upload(str(x), target_path)
+        else:
+            gcs.mkdir(target_path)
     gcs.invalidate_cache()
     yield f"gs://{bucket_name}", docker_gcs
 

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -159,7 +159,7 @@ def s3_server():
         timeout = 5
         while timeout > 0:
             try:
-                r = requests.get(endpoint_uri)
+                r = requests.get(endpoint_uri, timeout=10)
                 if r.ok:
                     break
             except Exception:  # pragma: no cover
@@ -226,7 +226,7 @@ def docker_gcs():
     timeout = 10
     while True:
         try:
-            r = requests.get(url + "/storage/v1/b")
+            r = requests.get(url + "/storage/v1/b", timeout=10)
             if r.ok:
                 yield url
                 break
@@ -272,7 +272,7 @@ def http_server():
             timeout = 10
             while True:
                 try:
-                    r = requests.get(url)
+                    r = requests.get(url, timeout=10)
                     if r.ok:
                         yield path, url
                         break

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -285,7 +285,7 @@ def http_server():
             shlex.split(f"python -m http.server --directory {tempdir} 8080")
         )
         try:
-            url = "http://0.0.0.0:8080/folder"
+            url = "http://127.0.0.1:8080/folder"
             path = Path(tempdir) / "folder"
             path.mkdir()
             timeout = 10

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -179,9 +179,9 @@ def s3_server():
 
 @pytest.fixture
 def s3_fixture(s3_server, local_testdir):
-    s3fs = pytest.importorskip("s3fs")
+    pytest.importorskip("s3fs")
     anon, s3so = s3_server
-    s3 = s3fs.S3FileSystem(anon=False, **s3so)
+    s3 = fsspec.filesystem("s3", anon=False, **s3so)
     bucket_name = "test_bucket"
     if s3.exists(bucket_name):
         for dir, _, keys in s3.walk(bucket_name):
@@ -228,7 +228,6 @@ def docker_gcs():
         try:
             r = requests.get(url + "/storage/v1/b")
             if r.ok:
-                print("url: ", url)
                 yield url
                 break
         except Exception as e:  # noqa: E722
@@ -241,13 +240,7 @@ def docker_gcs():
 
 @pytest.fixture
 def gcs_fixture(docker_gcs, local_testdir):
-    try:
-        from gcsfs.core import GCSFileSystem
-    except ImportError:
-        pytest.skip("gcsfs not installed")
-
-    # from gcsfs.credentials import GoogleCredentials
-    GCSFileSystem.clear_instance_cache()
+    pytest.importorskip("gcsfs")
     gcs = fsspec.filesystem("gcs", endpoint_url=docker_gcs)
     bucket_name = "test_bucket"
     if gcs.exists(bucket_name):

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -260,8 +260,6 @@ def gcs_fixture(docker_gcs, local_testdir):
         target_path = f"{bucket_name}/{x.relative_to(local_testdir)}"
         if x.is_file():
             gcs.upload(str(x), target_path)
-        else:
-            gcs.mkdir(target_path)
     gcs.invalidate_cache()
     yield f"gs://{bucket_name}", docker_gcs
 

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -311,5 +311,10 @@ def http_fixture(local_testdir, docker_http):
             shutil.rmtree(f)
         else:
             f.unlink()
-    shutil.copytree(local_testdir, docker_http_path, dirs_exist_ok=True)
+    # shutil.copytree(.., .., dirs_exist_ok=True) only exists fpr Python 3.8+
+    for f in Path(local_testdir).iterdir():
+        if f.is_dir():
+            shutil.copytree(f, docker_http_path / f.name)
+        else:
+            shutil.copy(f, docker_http_path / f.name)
     yield docker_http_url

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -242,7 +242,7 @@ def docker_gcs():
 
 
 @pytest.fixture
-def gcs_fixture(docker_gcs, tempdir, local_testdir):
+def gcs_fixture(docker_gcs, local_testdir):
     try:
         from gcsfs.core import GCSFileSystem
     except ImportError:
@@ -269,7 +269,7 @@ def gcs_fixture(docker_gcs, tempdir, local_testdir):
             else:
                 gcs.mkdir(target_path)
         gcs.invalidate_cache()
-        yield docker_gcs
+        yield "gs://test_bucket", docker_gcs
     finally:
         try:
             gcs.rm(gcs.find("tmp"))

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -11,10 +11,10 @@ from ..utils import skip_on_windows
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
-    def path(self, local_testdir, gcs_fixture):
-        scheme = "gs:/"
-        self.path = UPath(f"{scheme}{local_testdir}", endpoint_url=gcs_fixture)
-        self.endpoint_url = gcs_fixture
+    def path(self, gcs_fixture):
+        path, endpoint_url = gcs_fixture
+        self.path = UPath(path, endpoint_url=endpoint_url)
+        self.endpoint_url = endpoint_url
 
     def test_is_GCSPath(self):
         assert isinstance(self.path, GCSPath)

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -39,7 +39,10 @@ class TestGCSPath(BaseTests):
         scheme = self.path._url.scheme
         content = b"a,b,c\n1,2,3\n4,5,6"
 
-        p1 = f"{scheme}:///tmp/output1.csv"
+        if not fs.exists(f"{scheme}://tmp"):
+            fs.mkdir(f"{scheme}://tmp")
+
+        p1 = f"{scheme}://tmp/output1.csv"
         upath1 = UPath(p1, endpoint_url=self.endpoint_url)
         upath1.write_bytes(content)
         with fs.open(p1) as f:
@@ -47,7 +50,7 @@ class TestGCSPath(BaseTests):
         upath1.unlink()
 
         # write with fsspec, read with upath
-        p2 = f"{scheme}:///tmp/output2.csv"
+        p2 = f"{scheme}://tmp/output2.csv"
         with fs.open(p2, "wb") as f:
             f.write(content)
         upath2 = UPath(p2, endpoint_url=self.endpoint_url)

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -1,13 +1,13 @@
 import pytest
-import sys
 
 from upath import UPath
 from upath.implementations.gcs import GCSPath
 from upath.errors import NotDirectoryError
-from upath.tests.cases import BaseTests
+from ..cases import BaseTests
+from ..utils import skip_on_windows
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows bad")
+@skip_on_windows
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
     @pytest.fixture(autouse=True, scope="function")

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -11,10 +11,10 @@ from upath.tests.cases import BaseTests
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
-    def path(self, local_testdir, gcs):
+    def path(self, local_testdir, gcs_fixture):
         scheme = "gs:/"
-        self.path = UPath(f"{scheme}{local_testdir}", endpoint_url=gcs)
-        self.endpoint_url = gcs
+        self.path = UPath(f"{scheme}{local_testdir}", endpoint_url=gcs_fixture)
+        self.endpoint_url = gcs_fixture
 
     def test_is_GCSPath(self):
         assert isinstance(self.path, GCSPath)

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -24,15 +24,6 @@ class TestGCSPath(BaseTests):
         new_dir.joinpath("test.txt").touch()
         assert new_dir.exists()
 
-    def test_glob(self, pathlib_base):
-        mock_glob = list(self.path.glob("**.txt"))
-        path_glob = list(pathlib_base.glob("**/*.txt"))
-
-        assert len(mock_glob) == len(path_glob)
-        assert all(
-            map(lambda m: m.path in [str(p)[4:] for p in path_glob], mock_glob)
-        )
-
     def test_rmdir(self, local_testdir):
         dirname = "rmdir_test"
         mock_dir = self.path.joinpath(dirname)

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -36,13 +36,12 @@ class TestGCSPath(BaseTests):
 
     def test_fsspec_compat(self):
         fs = self.path.fs
-        scheme = self.path._url.scheme
         content = b"a,b,c\n1,2,3\n4,5,6"
 
-        if not fs.exists(f"{scheme}://tmp"):
-            fs.mkdir(f"{scheme}://tmp")
+        if not fs.exists("gs://tmp"):
+            fs.mkdir("gs://tmp")
 
-        p1 = f"{scheme}://tmp/output1.csv"
+        p1 = "gs://tmp/output1.csv"
         upath1 = UPath(p1, endpoint_url=self.endpoint_url)
         upath1.write_bytes(content)
         with fs.open(p1) as f:
@@ -50,7 +49,7 @@ class TestGCSPath(BaseTests):
         upath1.unlink()
 
         # write with fsspec, read with upath
-        p2 = f"{scheme}://tmp/output2.csv"
+        p2 = "gs://tmp/output2.csv"
         with fs.open(p2, "wb") as f:
             f.write(content)
         upath2 = UPath(p2, endpoint_url=self.endpoint_url)

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -24,7 +24,7 @@ class TestGCSPath(BaseTests):
         new_dir.joinpath("test.txt").touch()
         assert new_dir.exists()
 
-    def test_rmdir(self, local_testdir):
+    def test_rmdir(self):
         dirname = "rmdir_test"
         mock_dir = self.path.joinpath(dirname)
         mock_dir.joinpath("test.txt").write_text("hello")

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -33,25 +33,3 @@ class TestGCSPath(BaseTests):
         assert not mock_dir.exists()
         with pytest.raises(NotDirectoryError):
             self.path.joinpath("file1.txt").rmdir()
-
-    def test_fsspec_compat(self):
-        fs = self.path.fs
-        content = b"a,b,c\n1,2,3\n4,5,6"
-
-        if not fs.exists("gs://tmp"):
-            fs.mkdir("gs://tmp")
-
-        p1 = "gs://tmp/output1.csv"
-        upath1 = UPath(p1, endpoint_url=self.endpoint_url)
-        upath1.write_bytes(content)
-        with fs.open(p1) as f:
-            assert f.read() == content
-        upath1.unlink()
-
-        # write with fsspec, read with upath
-        p2 = "gs://tmp/output2.csv"
-        with fs.open(p2, "wb") as f:
-            f.write(content)
-        upath2 = UPath(p2, endpoint_url=self.endpoint_url)
-        assert upath2.read_bytes() == content
-        upath2.unlink()

--- a/upath/tests/implementations/test_hdfs.py
+++ b/upath/tests/implementations/test_hdfs.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 from upath import UPath
 from upath.implementations.hdfs import HDFSPath
-from upath.tests.cases import BaseTests
+from ..cases import BaseTests
 
 
 @pytest.mark.hdfs

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -28,7 +28,7 @@ def test_httpiterdir(docker_http, local_testdir):
 
     for p in UPath(local_testdir).iterdir():
         assert f"{docker_http}/{p.name}" in list(
-            str(pp) for pp in path.iterdir()
+            str(pp).rstrip("/") for pp in path.iterdir()
         )
     assert path.exists()
     assert path.is_dir()

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -26,8 +26,8 @@ def test_httpspath():
 
 class TestUPathHttp(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
-    def path(self, docker_http):
-        self.path = UPath(docker_http)
+    def path(self, http_fixture):
+        self.path = UPath(http_fixture)
 
     def test_mkdir(self):
         pass

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -5,7 +5,6 @@ from fsspec import get_filesystem_class
 from upath import UPath
 from upath.implementations.http import HTTPPath
 from ..cases import BaseTests
-from ..utils import skip_on_windows
 
 try:
     get_filesystem_class("http")
@@ -25,7 +24,6 @@ def test_httpspath():
     assert path.exists()
 
 
-@skip_on_windows
 class TestUPathHttp(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
     def path(self, http_fixture):

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -29,6 +29,9 @@ class TestUPathHttp(BaseTests):
     def path(self, http_fixture):
         self.path = UPath(http_fixture)
 
+    def test_work_at_root(self):
+        assert "folder" in (f.name for f in self.path.parent.iterdir())
+
     def test_mkdir(self):
         pass
 

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -1,11 +1,11 @@
-import sys
 import pytest  # noqa: F401
 
 from fsspec import get_filesystem_class
 
 from upath import UPath
 from upath.implementations.http import HTTPPath
-from upath.tests.cases import BaseTests
+from ..cases import BaseTests
+from ..utils import skip_on_windows
 
 try:
     get_filesystem_class("http")
@@ -25,7 +25,7 @@ def test_httpspath():
     assert path.exists()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows bad")
+@skip_on_windows
 class TestUPathHttp(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
     def path(self, http_fixture):

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -15,3 +15,20 @@ def test_httppath():
     path = UPath("http://example.com")
     assert isinstance(path, HTTPPath)
     assert path.exists()
+
+
+def test_httpspath():
+    path = UPath("https://example.com")
+    assert isinstance(path, HTTPPath)
+    assert path.exists()
+
+
+def test_httpiterdir(docker_http, local_testdir):
+    path = UPath(docker_http)
+
+    for p in UPath(local_testdir).iterdir():
+        assert f"{docker_http}/{p.name}" in list(
+            str(pp) for pp in path.iterdir()
+        )
+    assert path.exists()
+    assert path.is_dir()

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -5,6 +5,7 @@ from fsspec import get_filesystem_class
 from upath import UPath
 from upath.implementations.http import HTTPPath
 from ..cases import BaseTests
+from ..utils import skip_on_windows
 
 try:
     get_filesystem_class("http")
@@ -24,6 +25,7 @@ def test_httpspath():
     assert path.exists()
 
 
+@skip_on_windows
 class TestUPathHttp(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
     def path(self, http_fixture):

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -4,6 +4,7 @@ from fsspec import get_filesystem_class
 
 from upath import UPath
 from upath.implementations.http import HTTPPath
+from upath.tests.cases import BaseTests
 
 try:
     get_filesystem_class("http")
@@ -23,12 +24,22 @@ def test_httpspath():
     assert path.exists()
 
 
-def test_httpiterdir(docker_http, local_testdir):
-    path = UPath(docker_http)
+class TestUPathHttp(BaseTests):
+    @pytest.fixture(autouse=True, scope="function")
+    def path(self, docker_http):
+        self.path = UPath(docker_http)
 
-    for p in UPath(local_testdir).iterdir():
-        assert f"{docker_http}/{p.name}" in list(
-            str(pp).rstrip("/") for pp in path.iterdir()
-        )
-    assert path.exists()
-    assert path.is_dir()
+    def test_mkdir(self):
+        pass
+
+    def test_touch_unlink(self):
+        pass
+
+    def test_write_bytes(self, pathlib_base):
+        pass
+
+    def test_write_text(self, pathlib_base):
+        pass
+
+    def test_fsspec_compat(self):
+        pass

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -1,3 +1,4 @@
+import sys
 import pytest  # noqa: F401
 
 from fsspec import get_filesystem_class
@@ -24,6 +25,7 @@ def test_httpspath():
     assert path.exists()
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows bad")
 class TestUPathHttp(BaseTests):
     @pytest.fixture(autouse=True, scope="function")
     def path(self, http_fixture):

--- a/upath/tests/implementations/test_memory.py
+++ b/upath/tests/implementations/test_memory.py
@@ -3,7 +3,7 @@ import pytest
 
 from upath import UPath
 from upath.implementations.memory import MemoryPath
-from upath.tests.cases import BaseTests
+from ..cases import BaseTests
 
 
 class TestMemoryPath(BaseTests):

--- a/upath/tests/implementations/test_memory.py
+++ b/upath/tests/implementations/test_memory.py
@@ -8,7 +8,7 @@ from ..cases import BaseTests
 class TestMemoryPath(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, local_testdir):
-        path = f"memory://{local_testdir}"
+        path = f"memory:{local_testdir}"
         self.path = UPath(path)
         self.prepare_file_system()
 

--- a/upath/tests/implementations/test_memory.py
+++ b/upath/tests/implementations/test_memory.py
@@ -1,4 +1,3 @@
-import sys
 import pytest
 
 from upath import UPath
@@ -9,22 +8,9 @@ from ..cases import BaseTests
 class TestMemoryPath(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, local_testdir):
-        path = f"memory:/{local_testdir}"
+        path = f"memory://{local_testdir}"
         self.path = UPath(path)
         self.prepare_file_system()
 
     def test_is_MemoryPath(self):
         assert isinstance(self.path, MemoryPath)
-
-    def test_glob(self, pathlib_base):
-        mock_glob = list(self.path.glob("**.txt"))
-        path_glob = list(pathlib_base.glob("**/*.txt"))
-
-        assert len(mock_glob) == len(path_glob)
-        if not sys.platform.startswith("win"):  # need to fix windows tests here
-            assert all(
-                map(
-                    lambda m: m.path in [str(p)[4:] for p in path_glob],
-                    mock_glob,
-                )
-            )

--- a/upath/tests/implementations/test_memory.py
+++ b/upath/tests/implementations/test_memory.py
@@ -8,6 +8,8 @@ from ..cases import BaseTests
 class TestMemoryPath(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, local_testdir):
+        if not local_testdir.startswith("/"):
+            local_testdir = "/" + local_testdir
         path = f"memory:{local_testdir}"
         self.path = UPath(path)
         self.prepare_file_system()

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -41,6 +41,25 @@ class TestUPathS3(BaseTests):
         with pytest.raises(NotDirectoryError):
             self.path.joinpath("file1.txt").rmdir()
 
+    def test_iterdir_root(self):
+        client_kwargs = self.path._kwargs["client_kwargs"]
+        bucket_path = UPath("s3://test_bucket", client_kwargs=client_kwargs)
+        bucket_path.mkdir(mode="private")
+
+        (bucket_path / "test1.txt").touch()
+        (bucket_path / "test2.txt").touch()
+
+        for x in bucket_path.iterdir():
+            print(
+                "ITER3",
+                repr(x.name),
+                repr(x._drv),
+                repr(x._root),
+                repr(x._parts),
+            )
+            assert x.name != ""
+            assert x.exists()
+
     def test_touch_unlink(self):
         path = self.path.joinpath("test_touch.txt")
         path.touch()

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -6,10 +6,8 @@ from upath import UPath
 from upath.errors import NotDirectoryError
 from upath.implementations.s3 import S3Path
 from ..cases import BaseTests
-from ..utils import skip_on_windows
 
 
-@skip_on_windows
 class TestUPathS3(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, s3_fixture):

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -60,13 +60,6 @@ class TestUPathS3(BaseTests):
         (bucket_path / "test2.txt").touch()
 
         for x in bucket_path.iterdir():
-            print(
-                "ITER3",
-                repr(x.name),
-                repr(x._drv),
-                repr(x._root),
-                repr(x._parts),
-            )
             assert x.name != ""
             assert x.exists()
 

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -10,8 +10,8 @@ from upath.tests.cases import BaseTests
 
 class TestUPathS3(BaseTests):
     @pytest.fixture(autouse=True)
-    def path(self, local_testdir, s3):
-        anon, s3so = s3
+    def path(self, local_testdir, s3_fixture):
+        anon, s3so = s3_fixture
         path = f"s3:/{local_testdir}"
         self.path = UPath(path, anon=anon, **s3so)
         self.anon = anon

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -75,29 +75,6 @@ class TestUPathS3(BaseTests):
         # file doesn't exists, but missing_ok is True
         path.unlink(missing_ok=True)
 
-    # def test_fsspec_compat(self):
-    #     fs = self.path.fs
-    #     scheme = self.path._url.scheme
-    #     content = b"a,b,c\n1,2,3\n4,5,6"
-
-    #     if not fs.exists(f"{scheme}://tmp"):
-    #         fs.mkdir(f"{scheme}://tmp")
-
-    #     p1 = f"{scheme}://tmp/output1.csv"
-    #     upath1 = UPath(p1, anon=self.anon, **self.s3so)
-    #     upath1.write_bytes(content)
-    #     with fs.open(p1) as f:
-    #         assert f.read() == content
-    #     upath1.unlink()
-
-    #     # write with fsspec, read with upath
-    #     p2 = f"{scheme}://tmp/output2.csv"
-    #     with fs.open(p2, "wb") as f:
-    #         f.write(content)
-    #     upath2 = UPath(p2, anon=self.anon, **self.s3so)
-    #     assert upath2.read_bytes() == content
-    #     upath2.unlink()
-
     @pytest.mark.parametrize(
         "joiner", [["bucket", "path", "file"], "bucket/path/file"]
     )

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -84,28 +84,28 @@ class TestUPathS3(BaseTests):
         # file doesn't exists, but missing_ok is True
         path.unlink(missing_ok=True)
 
-    def test_fsspec_compat(self):
-        fs = self.path.fs
-        scheme = self.path._url.scheme
-        content = b"a,b,c\n1,2,3\n4,5,6"
+    # def test_fsspec_compat(self):
+    #     fs = self.path.fs
+    #     scheme = self.path._url.scheme
+    #     content = b"a,b,c\n1,2,3\n4,5,6"
 
-        if not fs.exists(f"{scheme}://tmp"):
-            fs.mkdir(f"{scheme}://tmp")
+    #     if not fs.exists(f"{scheme}://tmp"):
+    #         fs.mkdir(f"{scheme}://tmp")
 
-        p1 = f"{scheme}://tmp/output1.csv"
-        upath1 = UPath(p1, anon=self.anon, **self.s3so)
-        upath1.write_bytes(content)
-        with fs.open(p1) as f:
-            assert f.read() == content
-        upath1.unlink()
+    #     p1 = f"{scheme}://tmp/output1.csv"
+    #     upath1 = UPath(p1, anon=self.anon, **self.s3so)
+    #     upath1.write_bytes(content)
+    #     with fs.open(p1) as f:
+    #         assert f.read() == content
+    #     upath1.unlink()
 
-        # write with fsspec, read with upath
-        p2 = f"{scheme}://tmp/output2.csv"
-        with fs.open(p2, "wb") as f:
-            f.write(content)
-        upath2 = UPath(p2, anon=self.anon, **self.s3so)
-        assert upath2.read_bytes() == content
-        upath2.unlink()
+    #     # write with fsspec, read with upath
+    #     p2 = f"{scheme}://tmp/output2.csv"
+    #     with fs.open(p2, "wb") as f:
+    #         f.write(content)
+    #     upath2 = UPath(p2, anon=self.anon, **self.s3so)
+    #     assert upath2.read_bytes() == content
+    #     upath2.unlink()
 
     @pytest.mark.parametrize(
         "joiner", [["bucket", "path", "file"], "bucket/path/file"]

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -1,5 +1,6 @@
 """see upath/tests/conftest.py for fixtures
 """
+import sys
 import pytest  # noqa: F401
 
 from upath import UPath
@@ -8,6 +9,7 @@ from upath.implementations.s3 import S3Path
 from upath.tests.cases import BaseTests
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows bad")
 class TestUPathS3(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, local_testdir, s3_fixture):

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -69,7 +69,10 @@ class TestUPathS3(BaseTests):
         scheme = self.path._url.scheme
         content = b"a,b,c\n1,2,3\n4,5,6"
 
-        p1 = f"{scheme}:///tmp/output1.csv"
+        if not fs.exists(f"{scheme}://tmp"):
+            fs.mkdir(f"{scheme}://tmp")
+
+        p1 = f"{scheme}://tmp/output1.csv"
         upath1 = UPath(p1, anon=self.anon, **self.s3so)
         upath1.write_bytes(content)
         with fs.open(p1) as f:
@@ -77,7 +80,7 @@ class TestUPathS3(BaseTests):
         upath1.unlink()
 
         # write with fsspec, read with upath
-        p2 = f"{scheme}:///tmp/output2.csv"
+        p2 = f"{scheme}://tmp/output2.csv"
         with fs.open(p2, "wb") as f:
             f.write(content)
         upath2 = UPath(p2, anon=self.anon, **self.s3so)

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -31,7 +31,7 @@ class TestUPathS3(BaseTests):
         new_dir.joinpath("test.txt").touch()
         assert new_dir.exists()
 
-    def test_rmdir(self, local_testdir):
+    def test_rmdir(self):
         dirname = "rmdir_test"
         mock_dir = self.path.joinpath(dirname)
         mock_dir.joinpath("test.txt").touch()

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -227,3 +227,21 @@ def test_copy_path_append_kwargs():
     assert str(path) == str(copy_path)
     assert not copy_path._kwargs["anon"]
     assert path._kwargs["anon"]
+
+
+def test_relative_to():
+    assert "s3://test_bucket/file.txt" == str(
+        UPath("s3://test_bucket/file.txt").relative_to(
+            UPath("s3://test_bucket")
+        )
+    )
+
+    with pytest.raises(ValueError):
+        UPath("s3://test_bucket/file.txt").relative_to(
+            UPath("gcs://test_bucket")
+        )
+
+    with pytest.raises(ValueError):
+        UPath("s3://test_bucket/file.txt", anon=True).relative_to(
+            UPath("s3://test_bucket", anon=False)
+        )

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -6,21 +6,16 @@ import warnings
 import pytest
 from upath import UPath
 from upath.implementations.s3 import S3Path
-from upath.tests.cases import BaseTests
+from .cases import BaseTests
+from .utils import only_on_windows, skip_on_windows
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="don't run test on Windows",
-)
+@skip_on_windows
 def test_posix_path(local_testdir):
     assert isinstance(UPath(local_testdir), pathlib.PosixPath)
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("win"),
-    reason="only run test if Windows Machine",
-)
+@only_on_windows
 def test_windows_path(local_testdir):
     assert isinstance(UPath(local_testdir), pathlib.WindowsPath)
 
@@ -107,10 +102,7 @@ def test_new_method(local_testdir):
     assert not isinstance(path, UPath)
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="don't run test on Windows",
-)  # need to fix windows tests here
+@skip_on_windows
 class TestFSSpecLocal(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, local_testdir):

--- a/upath/tests/utils.py
+++ b/upath/tests/utils.py
@@ -1,0 +1,18 @@
+import sys
+import pytest
+
+
+def skip_on_windows(func):
+    return pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="Don't run on Windows"
+    )(func)
+
+
+def only_on_windows(func):
+    return pytest.mark.skipif(
+        not sys.platform.startswith("win"), reason="Only run on Windows"
+    )(func)
+
+
+def posixify(path):
+    return str(path).replace("\\", "/")


### PR DESCRIPTION
When calling `iterdir` on a `HTTPPath`, it uses the base implementation from `UPath`. Since `fsspec` returns not only the path but the complete address (i.e. `http://example.com/path/to/a`) and the `_sub_path` implementation from `UPath` expects only `/path/to/a`, it fails.

To fix this, this PR introduces a `_sub_path` implementation to `HTTPPath` which takes the `scheme` and `netloc` into account.

Additional changes:
- Reimplements `is_file` and `is_dir` within `HTTPPath`. [`fsspec` only distinguishes between both based on the existence of a trailing slash](https://github.com/fsspec/filesystem_spec/blob/45dcfa99e2dc320bf072c28bef767b71f8299a4a/fsspec/implementations/http.py#L183) which is not really great for real world deployments.
- Re-add S3 tests in CI by fixing `moto`
- S3, GCS, Http tests now reuse most of `BaseTests`
- `UPath` got a dedicated `relative_to` method, because the `pathlib.Path` version removed the kwargs
- `UPath` now has stubs for not-implemented methods instead of `__getattribute__` magic
- Some fixes for Windows (e.g. remove use of `os.path.join` in `GCSPath` and `S3Path`)
- Add `tests/utils` module
- Refactor `_Registry` to use a dedicated dict for implementations instead of class attributes (eliminates module-attribute naming conflicts, e.g. `http = http.HTTPPath`)
- `is_file`, `is_dir`, `is_symlink` no longer raise `FileNotFoundError`, but return `False` if path is non-existent
- Strips `_url` from `_kwargs` to reduce redundancy + refactorings in `_from_parts` and `_from_parsed_parts`