### PR TITLE
UPath.open: add mode argument default

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -29,8 +29,8 @@ class _FSSpecAccessor:
     def _format_path(self, path: "UPath") -> str:
         return path.path
 
-    def open(self, path, *args, **kwargs):
-        return self._fs.open(self._format_path(path), *args, **kwargs)
+    def open(self, path, mode='r', *args, **kwargs):
+        return self._fs.open(self._format_path(path), mode, *args, **kwargs)
 
     def stat(self, path, **kwargs):
         return self._fs.stat(self._format_path(path), **kwargs)


### PR DESCRIPTION
The missing default for the `mode` argument lead to errors, as the default of `HTTPFile` in fsspec is `rb`, not `r` as in Paths.

E.g. the following command produced an error before, which is fixed by using the actual Path implementation default now:
```python
from upath import UPath
UPath("http://raw.githubusercontent.com/fsspec/universal_pathlib/main/README.md").open(encoding="utf-8").read()
```