### PR TITLE
add adlfs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For more examples, see the [example notebook here](notebooks/examples.ipynb)
 
 - `file:` Local filessystem
 - `memory:` Ephemeral filesystem in RAM
+- `az:`, `adl:` and `abfs:` Azure Storage (requires `adlfs` to be installed)
 - `http:` and `https:` HTTP(S)-based filesystem
 - `hdfs:` Hadoop distributed filesystem
 - `gs:` and `gcs:` Google Cloud Storage (requires `gcsfs` to be installed)

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,6 +29,7 @@ def install(session):
 def smoke(session):
     session.install(
         "pytest",
+        "adlfs",
         "aiohttp",
         "requests",
         "gcsfs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = []
 doc = []
 test = [
   "aiohttp",
+  "adlfs",
   "flake8",
   "gcsfs",
   "hadoop-test-cluster",

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -61,3 +61,7 @@ class GCSPath(CloudPath):
 
 class S3Path(CloudPath):
     pass
+
+
+class AzurePath(CloudPath):
+    pass

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -6,17 +6,20 @@ from upath.core import UPath
 
 
 class _Registry:
-    from upath.implementations import hdfs, http, memory, cloud, webdav
+    from upath.implementations import cloud, hdfs, http, memory, webdav
 
     known_implementations: Dict[str, Type[UPath]] = {
-        "https": http.HTTPPath,
-        "http": http.HTTPPath,
-        "hdfs": hdfs.HDFSPath,
-        "s3a": cloud.S3Path,
-        "s3": cloud.S3Path,
-        "memory": memory.MemoryPath,
-        "gs": cloud.GCSPath,
+        "abfs": cloud.AzurePath,
+        "adl": cloud.AzurePath,
+        "az": cloud.AzurePath,
         "gcs": cloud.GCSPath,
+        "gs": cloud.GCSPath,
+        "hdfs": hdfs.HDFSPath,
+        "http": http.HTTPPath,
+        "https": http.HTTPPath,
+        "memory": memory.MemoryPath,
+        "s3": cloud.S3Path,
+        "s3a": cloud.S3Path,
         "webdav+http": webdav.WebdavPath,
         "webdav+https": webdav.WebdavPath,
     }

--- a/upath/tests/implementations/test_azure.py
+++ b/upath/tests/implementations/test_azure.py
@@ -1,0 +1,44 @@
+import pytest
+from upath import UPath
+from upath.errors import NotDirectoryError
+from upath.implementations.cloud import AzurePath
+
+from ..cases import BaseTests
+from ..utils import skip_on_windows
+
+
+@skip_on_windows
+@pytest.mark.usefixtures("path")
+class TestAzurePath(BaseTests):
+    @pytest.fixture(autouse=True, scope="function")
+    def path(self, azurite_credentials, azure_fixture):
+        account_name, connection_string = azurite_credentials
+
+        self.storage_options = {
+            "account_name": account_name,
+            "connection_string": connection_string,
+        }
+        self.path = UPath(azure_fixture, **self.storage_options)
+        self.prepare_file_system()
+
+    def test_is_AzurePath(self):
+        assert isinstance(self.path, AzurePath)
+
+    def test_mkdir(self):
+        new_dir = self.path / "new_dir"
+        new_dir.mkdir()
+        (new_dir / "test.txt").touch()
+        assert new_dir.exists()
+
+    def test_rmdir(self):
+        new_dir = self.path / "new_dir"
+        new_dir.mkdir()
+        path = new_dir / "test.txt"
+        path.write_text("hello")
+        assert path.exists()
+        new_dir.fs.invalidate_cache()
+        new_dir.rmdir()
+        assert not new_dir.exists()
+
+        with pytest.raises(NotDirectoryError):
+            (self.path / "a" / "file.txt").rmdir()


### PR DESCRIPTION
Azure Storage was already working out of the box, I just explicitly added `AzurePath` and a fixture to mock azure using [Azurite](https://github.com/Azure/Azurite/) to do some testing. The fixture follows `gcs_fixture`, but I might open a PR migrating these both    to [`pytest-docker`](https://github.com/avast/pytest-docker) if that's useful.

Closes #48 