### PR TITLE
Fix python311 compatibility

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import nox
 from pathlib import Path
 
@@ -27,6 +30,12 @@ def install(session):
 
 @nox.session()
 def smoke(session):
+    if (3, 10) < sys.version_info <= (3, 11, 0, "final"):
+        # workaround for missing aiohttp wheels for py3.11
+        session.install("aiohttp", "--no-binary", "aiohttp", env={
+            "AIOHTTP_NO_EXTENSIONS": "1"
+        })
+
     session.install(
         "pytest",
         "adlfs",

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import nox
@@ -20,7 +19,7 @@ def black(session):
 @nox.session()
 def lint(session):
     session.install("flake8")
-    session.run(*"flake8".split())
+    session.run("flake8", "upath")
 
 
 @nox.session()

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setuptools.setup(
     description="pathlib api extended to use fsspec backends",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    license="MIT"
+    license="MIT",
 )

--- a/upath/core.py
+++ b/upath/core.py
@@ -385,14 +385,18 @@ class UPath(pathlib.Path):
         if parents:
             self._accessor.mkdir(
                 self,
-                create_parents=parents,
+                create_parents=True,
                 exist_ok=exist_ok,
-                permissions=mode,
+                mode=mode,
             )
         else:
             try:
-                self._accessor.mkdir(self, create_parents=False)
-            except OSError:
+                self._accessor.mkdir(
+                    self,
+                    create_parents=False,
+                    mode=mode,
+                )
+            except FileExistsError:
                 if not exist_ok or not self.is_dir():
                     raise
 

--- a/upath/core.py
+++ b/upath/core.py
@@ -342,6 +342,19 @@ class UPath(pathlib.Path):
     def touch(self, truncate=True, **kwargs):
         self._accessor.touch(self, truncate=truncate, **kwargs)
 
+    def mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        """
+        Create a new directory at this given path.
+        """
+        if parents:
+            self._accessor.mkdir(self, create_parents=parents, exist_ok=exist_ok, permissions=mode)
+        else:
+            try:
+                self._accessor.mkdir(self, create_parents=False)
+            except OSError:
+                if not exist_ok or not self.is_dir():
+                    raise
+
     @classmethod
     def _from_parts(cls, args, url=None, **kwargs):
         obj = object.__new__(cls)

--- a/upath/core.py
+++ b/upath/core.py
@@ -484,7 +484,7 @@ class UPath(pathlib.Path):
         f = self._flavour
         if f.sep in suffix or f.altsep and f.altsep in suffix:
             raise ValueError("Invalid suffix %r" % (suffix,))
-        if suffix and not suffix.startswith('.') or suffix == '.':
+        if suffix and not suffix.startswith(".") or suffix == ".":
             raise ValueError("Invalid suffix %r" % (suffix))
         name = self.name
         if not name:
@@ -493,17 +493,24 @@ class UPath(pathlib.Path):
         if not old_suffix:
             name = name + suffix
         else:
-            name = name[:-len(old_suffix)] + suffix
-        return self._from_parsed_parts(self._drv, self._root,
-                                       self._parts[:-1] + [name], url=self._url)
+            name = name[: -len(old_suffix)] + suffix
+        return self._from_parsed_parts(
+            self._drv, self._root, self._parts[:-1] + [name], url=self._url
+        )
 
     def with_name(self, name):
         """Return a new path with the file name changed."""
         if not self.name:
             raise ValueError("%r has an empty name" % (self,))
         drv, root, parts = self._flavour.parse_parts((name,))
-        if (not name or name[-1] in [self._flavour.sep, self._flavour.altsep]
-                or drv or root or len(parts) != 1):
+        if (
+            not name
+            or name[-1] in [self._flavour.sep, self._flavour.altsep]
+            or drv
+            or root
+            or len(parts) != 1
+        ):
             raise ValueError("Invalid name %r" % (name))
-        return self._from_parsed_parts(self._drv, self._root,
-                                       self._parts[:-1] + [name], url=self._url)
+        return self._from_parsed_parts(
+            self._drv, self._root, self._parts[:-1] + [name], url=self._url
+        )

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -3,11 +3,21 @@ import re
 
 
 class _CloudAccessor(upath.core._FSSpecAccessor):
+
     def _format_path(self, path):
         """
         netloc has already been set to project via `CloudPath._from_parts`
         """
         return f"{path._url.netloc}/{path.path.lstrip('/')}"
+
+    def mkdir(self, path, create_parents=True, **kwargs):
+        if (
+            not create_parents
+            and not kwargs.get("exist_ok", False)
+            and self._fs.exists(self._format_path(path))
+        ):
+            raise FileExistsError
+        return super().mkdir(path, create_parents=create_parents, **kwargs)
 
 
 # project is not part of the path, but is part of the credentials

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -3,7 +3,6 @@ import re
 
 
 class _CloudAccessor(upath.core._FSSpecAccessor):
-
     def _format_path(self, path):
         """
         netloc has already been set to project via `CloudPath._from_parts`

--- a/upath/implementations/hdfs.py
+++ b/upath/implementations/hdfs.py
@@ -13,15 +13,11 @@ class _HDFSAccessor(upath.core._FSSpecAccessor):
     def mkdir(self, path, create_parents=True, **kwargs):
         pth = self._format_path(path)
         if create_parents:
-            return self._fs.makedirs(
-                pth, **kwargs
-            )
+            return self._fs.makedirs(pth, **kwargs)
         else:
             if not kwargs.get("exist_ok", False) and self._fs.exists(pth):
                 raise FileExistsError
-            return self._fs.mkdir(
-                pth, create_parents=create_parents, **kwargs
-            )
+            return self._fs.mkdir(pth, create_parents=create_parents, **kwargs)
 
 
 class HDFSPath(upath.core.UPath):

--- a/upath/implementations/hdfs.py
+++ b/upath/implementations/hdfs.py
@@ -10,6 +10,19 @@ class _HDFSAccessor(upath.core._FSSpecAccessor):
         kwargs.pop("truncate", None)
         super().touch(path, **kwargs)
 
+    def mkdir(self, path, create_parents=True, **kwargs):
+        pth = self._format_path(path)
+        if create_parents:
+            return self._fs.makedirs(
+                pth, **kwargs
+            )
+        else:
+            if not kwargs.get("exist_ok", False) and self._fs.exists(pth):
+                raise FileExistsError
+            return self._fs.mkdir(
+                pth, create_parents=create_parents, **kwargs
+            )
+
 
 class HDFSPath(upath.core.UPath):
     _default_accessor = _HDFSAccessor

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -126,6 +126,17 @@ class BaseTests:
         new_dir.mkdir()
         assert new_dir.exists()
 
+    def test_mkdir_exists_ok_true(self):
+        new_dir = self.path.joinpath("new_dir_may_exists")
+        new_dir.mkdir()
+        new_dir.mkdir(exist_ok=True)
+
+    def test_mkdir_exists_ok_false(self):
+        new_dir = self.path.joinpath("new_dir_may_not_exists")
+        new_dir.mkdir()
+        with pytest.raises(FileExistsError):
+            new_dir.mkdir(exist_ok=False)
+
     def test_open(self):
         pass
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -9,6 +9,8 @@ from .utils import posixify
 
 
 class BaseTests:
+    MKDIR_REQUIRES_FILE = False
+
     def test_cwd(self):
         with pytest.raises(NotImplementedError):
             self.path.cwd()
@@ -124,16 +126,22 @@ class BaseTests:
     def test_mkdir(self):
         new_dir = self.path.joinpath("new_dir")
         new_dir.mkdir()
+        if self.MKDIR_REQUIRES_FILE:
+            new_dir.joinpath(".file").touch()
         assert new_dir.exists()
 
     def test_mkdir_exists_ok_true(self):
         new_dir = self.path.joinpath("new_dir_may_exists")
         new_dir.mkdir()
+        if self.MKDIR_REQUIRES_FILE:
+            new_dir.joinpath(".file").touch()
         new_dir.mkdir(exist_ok=True)
 
     def test_mkdir_exists_ok_false(self):
         new_dir = self.path.joinpath("new_dir_may_not_exists")
         new_dir.mkdir()
+        if self.MKDIR_REQUIRES_FILE:
+            new_dir.joinpath(".file").touch()
         with pytest.raises(FileExistsError):
             new_dir.mkdir(exist_ok=False)
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -9,7 +9,7 @@ from .utils import posixify
 
 
 class BaseTests:
-    MKDIR_REQUIRES_FILE = False
+    SUPPORTS_EMPTY_DIRS = True
 
     def test_cwd(self):
         with pytest.raises(NotImplementedError):
@@ -126,21 +126,21 @@ class BaseTests:
     def test_mkdir(self):
         new_dir = self.path.joinpath("new_dir")
         new_dir.mkdir()
-        if self.MKDIR_REQUIRES_FILE:
+        if not self.SUPPORTS_EMPTY_DIRS:
             new_dir.joinpath(".file").touch()
         assert new_dir.exists()
 
     def test_mkdir_exists_ok_true(self):
         new_dir = self.path.joinpath("new_dir_may_exists")
         new_dir.mkdir()
-        if self.MKDIR_REQUIRES_FILE:
+        if not self.SUPPORTS_EMPTY_DIRS:
             new_dir.joinpath(".file").touch()
         new_dir.mkdir(exist_ok=True)
 
     def test_mkdir_exists_ok_false(self):
         new_dir = self.path.joinpath("new_dir_may_not_exists")
         new_dir.mkdir()
-        if self.MKDIR_REQUIRES_FILE:
+        if not self.SUPPORTS_EMPTY_DIRS:
             new_dir.joinpath(".file").touch()
         with pytest.raises(FileExistsError):
             new_dir.mkdir(exist_ok=False)

--- a/upath/tests/implementations/test_azure.py
+++ b/upath/tests/implementations/test_azure.py
@@ -10,7 +10,7 @@ from ..utils import skip_on_windows
 @skip_on_windows
 @pytest.mark.usefixtures("path")
 class TestAzurePath(BaseTests):
-    MKDIR_REQUIRES_FILE = True
+    SUPPORTS_EMPTY_DIRS = False
 
     @pytest.fixture(autouse=True, scope="function")
     def path(self, azurite_credentials, azure_fixture):

--- a/upath/tests/implementations/test_azure.py
+++ b/upath/tests/implementations/test_azure.py
@@ -10,6 +10,8 @@ from ..utils import skip_on_windows
 @skip_on_windows
 @pytest.mark.usefixtures("path")
 class TestAzurePath(BaseTests):
+    MKDIR_REQUIRES_FILE = True
+
     @pytest.fixture(autouse=True, scope="function")
     def path(self, azurite_credentials, azure_fixture):
         account_name, connection_string = azurite_credentials
@@ -24,14 +26,8 @@ class TestAzurePath(BaseTests):
     def test_is_AzurePath(self):
         assert isinstance(self.path, AzurePath)
 
-    def test_mkdir(self):
-        new_dir = self.path / "new_dir"
-        new_dir.mkdir()
-        (new_dir / "test.txt").touch()
-        assert new_dir.exists()
-
     def test_rmdir(self):
-        new_dir = self.path / "new_dir"
+        new_dir = self.path / "new_dir_rmdir"
         new_dir.mkdir()
         path = new_dir / "test.txt"
         path.write_text("hello")

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -10,7 +10,7 @@ from ..utils import skip_on_windows
 @skip_on_windows
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
-    MKDIR_REQUIRES_FILE = True
+    SUPPORTS_EMPTY_DIRS = False
 
     @pytest.fixture(autouse=True, scope="function")
     def path(self, gcs_fixture):

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -10,6 +10,8 @@ from ..utils import skip_on_windows
 @skip_on_windows
 @pytest.mark.usefixtures("path")
 class TestGCSPath(BaseTests):
+    MKDIR_REQUIRES_FILE = True
+
     @pytest.fixture(autouse=True, scope="function")
     def path(self, gcs_fixture):
         path, endpoint_url = gcs_fixture
@@ -18,11 +20,6 @@ class TestGCSPath(BaseTests):
 
     def test_is_GCSPath(self):
         assert isinstance(self.path, GCSPath)
-
-    def test_mkdir(self):
-        new_dir = self.path.joinpath("new_dir")
-        new_dir.joinpath("test.txt").touch()
-        assert new_dir.exists()
 
     def test_rmdir(self):
         dirname = "rmdir_test"

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -34,15 +34,27 @@ class TestUPathHttp(BaseTests):
     def test_work_at_root(self):
         assert "folder" in (f.name for f in self.path.parent.iterdir())
 
+    @pytest.mark.skip
     def test_mkdir(self):
         pass
 
+    @pytest.mark.skip
+    def test_mkdir_exists_ok_false(self):
+        pass
+
+    @pytest.mark.skip
+    def test_mkdir_exists_ok_true(self):
+        pass
+
+    @pytest.mark.skip
     def test_touch_unlink(self):
         pass
 
+    @pytest.mark.skip
     def test_write_bytes(self, pathlib_base):
         pass
 
+    @pytest.mark.skip
     def test_write_text(self, pathlib_base):
         pass
 

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -9,6 +9,8 @@ from ..cases import BaseTests
 
 
 class TestUPathS3(BaseTests):
+    MKDIR_REQUIRES_FILE = True
+
     @pytest.fixture(autouse=True)
     def path(self, s3_fixture):
         path, anon, s3so = s3_fixture
@@ -22,14 +24,6 @@ class TestUPathS3(BaseTests):
     def test_chmod(self):
         # todo
         pass
-
-    def test_mkdir(self):
-        new_dir = self.path.joinpath("new_dir")
-        # new_dir.mkdir()
-        # mkdir doesn't really do anything. A directory only exists in s3
-        # if some file or something is written to it
-        new_dir.joinpath("test.txt").touch()
-        assert new_dir.exists()
 
     def test_rmdir(self):
         dirname = "rmdir_test"

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -9,7 +9,7 @@ from ..cases import BaseTests
 
 
 class TestUPathS3(BaseTests):
-    MKDIR_REQUIRES_FILE = True
+    SUPPORTS_EMPTY_DIRS = False
 
     @pytest.fixture(autouse=True)
     def path(self, s3_fixture):


### PR DESCRIPTION
Hello everyone,

this fixes all tests under Python 3.11. And it closes #67.
It basically only required to provide a working `mkdir` method for the testsuite to pass.

In Python 3.11's pathlib the `_accessor` classes have been removed and so UPath's implementation deviates now a little bit from the new pathlib implementation. It's not really problematic for now, if we explicitly disable all that is not working (I raise `NotImplementedError` in many methods that now rely directly on `os.path` functions). If needed, some of these disabled methods could probably be implemented in an fsspec compatible way.

Once python/cpython#31691 and later python/cpython#31085 are merged into python, I believe this should be revisited.

Cheers,
Andreas :smiley: 

 