### PR TITLE
fix broken with_* methods

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -417,3 +417,35 @@ class UPath(pathlib.Path):
             (self._format_parsed_parts(self._drv, self._root, self._parts),),
             {"_kwargs": self._kwargs.copy()},
         )
+
+    def with_suffix(self, suffix):
+        """Return a new path with the file suffix changed.  If the path
+        has no suffix, add given suffix.  If the given suffix is an empty
+        string, remove the suffix from the path.
+        """
+        f = self._flavour
+        if f.sep in suffix or f.altsep and f.altsep in suffix:
+            raise ValueError("Invalid suffix %r" % (suffix,))
+        if suffix and not suffix.startswith('.') or suffix == '.':
+            raise ValueError("Invalid suffix %r" % (suffix))
+        name = self.name
+        if not name:
+            raise ValueError("%r has an empty name" % (self,))
+        old_suffix = self.suffix
+        if not old_suffix:
+            name = name + suffix
+        else:
+            name = name[:-len(old_suffix)] + suffix
+        return self._from_parsed_parts(self._drv, self._root,
+                                       self._parts[:-1] + [name], url=self._url)
+
+    def with_name(self, name):
+        """Return a new path with the file name changed."""
+        if not self.name:
+            raise ValueError("%r has an empty name" % (self,))
+        drv, root, parts = self._flavour.parse_parts((name,))
+        if (not name or name[-1] in [self._flavour.sep, self._flavour.altsep]
+            or drv or root or len(parts) != 1):
+            raise ValueError("Invalid name %r" % (name))
+        return self._from_parsed_parts(self._drv, self._root,
+                                       self._parts[:-1] + [name], url=self._url)

--- a/upath/core.py
+++ b/upath/core.py
@@ -445,7 +445,7 @@ class UPath(pathlib.Path):
             raise ValueError("%r has an empty name" % (self,))
         drv, root, parts = self._flavour.parse_parts((name,))
         if (not name or name[-1] in [self._flavour.sep, self._flavour.altsep]
-            or drv or root or len(parts) != 1):
+                or drv or root or len(parts) != 1):
             raise ValueError("Invalid name %r" % (name))
         return self._from_parsed_parts(self._drv, self._root,
                                        self._parts[:-1] + [name], url=self._url)

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -290,3 +290,28 @@ class BaseTests:
         assert path._root == copy_path._root
         assert path._parts == copy_path._parts
         assert path.fs.storage_options == copy_path.fs.storage_options
+
+    def test_with_name(self):
+        path = self.path / "file.txt"
+        path = path.with_name("file.zip")
+        assert path.name == "file.zip"
+
+    def test_with_suffix(self):
+        path = self.path / "file.txt"
+        path = path.with_suffix(".zip")
+        assert path.suffix == ".zip"
+
+    def test_with_stem(self):
+        if sys.version_info < (3, 9):
+            pytest.skip("with_stem only available on py3.9+")
+        path = self.path / "file.txt"
+        path = path.with_stem("document")
+        assert path.stem == "document"
+
+    def test_repr_after_with_name(self):
+        p = self.path.joinpath("file.txt").with_name("file.zip")
+        assert "file.zip" in repr(p)
+
+    def test_repr_after_with_suffix(self):
+        p = self.path.joinpath("file.txt").with_suffix(".zip")
+        assert "file.zip" in repr(p)


### PR DESCRIPTION
Adds tests for on `with_*` methods on UPath.
And fixes issue where `._url` was not carried over in those methods.

Closes #72 