### PR TITLE
Fix NotADirectoryError

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -12,8 +12,6 @@ from fsspec.registry import (
 )
 from fsspec.utils import stringify_path
 
-from upath.errors import NotDirectoryError
-
 
 class _FSSpecAccessor:
     __slots__ = ("_fs",)
@@ -302,10 +300,8 @@ class UPath(pathlib.Path):
         """Add warning if directory not empty
         assert is_dir?
         """
-        try:
-            assert self.is_dir()
-        except AssertionError:
-            raise NotDirectoryError
+        if not self.is_dir():
+            raise NotADirectoryError
         self._accessor.rm(self, recursive=recursive)
 
     def chmod(self, mod):

--- a/upath/core.py
+++ b/upath/core.py
@@ -34,7 +34,17 @@ class _FSSpecAccessor:
         return self._fs.stat(self._format_path(path), **kwargs)
 
     def listdir(self, path, **kwargs):
-        return self._fs.listdir(self._format_path(path), **kwargs)
+        p_fmt = self._format_path(path)
+        contents = self._fs.listdir(p_fmt, **kwargs)
+        if len(contents) == 0 and not self._fs.isdir(p_fmt):
+            raise NotADirectoryError
+        elif (
+            len(contents) == 1
+            and contents[0]["name"] == p_fmt
+            and contents[0]["type"] == "file"
+        ):
+            raise NotADirectoryError
+        return contents
 
     def glob(self, _path, path_pattern, **kwargs):
         return self._fs.glob(self._format_path(path_pattern), **kwargs)

--- a/upath/errors.py
+++ b/upath/errors.py
@@ -4,7 +4,8 @@ import warnings
 def __getattr__(name):
     if name == "NotDirectoryError":
         warnings.warn(
-            "upath.errors.NotDirectoryError is deprecated. Use NotADirectoryError instead",
+            "upath.errors.NotDirectoryError is deprecated. "
+            "Use NotADirectoryError instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/upath/errors.py
+++ b/upath/errors.py
@@ -1,2 +1,12 @@
-class NotDirectoryError(Exception):
-    pass
+import warnings
+
+
+def __getattr__(name):
+    if name == "NotDirectoryError":
+        warnings.warn(
+            "upath.errors.NotDirectoryError is deprecated. Use NotADirectoryError instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return NotADirectoryError
+    raise AttributeError(name)

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -25,13 +25,12 @@ class HTTPPath(upath.core.UPath):
             return False
 
     def _path_type(self):
-        info = self._accessor.info(self)
-        if (
-            info["type"] == "directory"
-            or next(self.iterdir(), None) is not None
-        ):
+        try:
+            next(self.iterdir())
+        except (StopIteration, NotADirectoryError):
+            return "file"
+        else:
             return "directory"
-        return "file"
 
     def _sub_path(self, name):
         """

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -315,3 +315,14 @@ class BaseTests:
     def test_repr_after_with_suffix(self):
         p = self.path.joinpath("file.txt").with_suffix(".zip")
         assert "file.zip" in repr(p)
+
+    def test_rmdir_no_dir(self):
+        p = self.path.joinpath("file1.txt")
+        with pytest.raises(NotADirectoryError):
+            p.rmdir()
+
+    def test_iterdir_no_dir(self):
+        p = self.path.joinpath("file1.txt")
+        assert p.is_file()
+        with pytest.raises(NotADirectoryError):
+            _ = list(p.iterdir())

--- a/upath/tests/implementations/test_azure.py
+++ b/upath/tests/implementations/test_azure.py
@@ -1,6 +1,5 @@
 import pytest
 from upath import UPath
-from upath.errors import NotDirectoryError
 from upath.implementations.cloud import AzurePath
 
 from ..cases import BaseTests
@@ -40,5 +39,5 @@ class TestAzurePath(BaseTests):
         new_dir.rmdir()
         assert not new_dir.exists()
 
-        with pytest.raises(NotDirectoryError):
+        with pytest.raises(NotADirectoryError):
             (self.path / "a" / "file.txt").rmdir()

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -2,7 +2,6 @@ import pytest
 
 from upath import UPath
 from upath.implementations.cloud import GCSPath
-from upath.errors import NotDirectoryError
 from ..cases import BaseTests
 from ..utils import skip_on_windows
 
@@ -31,5 +30,5 @@ class TestGCSPath(BaseTests):
         mock_dir.fs.invalidate_cache()
         mock_dir.rmdir()
         assert not mock_dir.exists()
-        with pytest.raises(NotDirectoryError):
+        with pytest.raises(NotADirectoryError):
             self.path.joinpath("file1.txt").rmdir()

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -3,7 +3,6 @@
 import pytest  # noqa: F401
 
 from upath import UPath
-from upath.errors import NotDirectoryError
 from upath.implementations.cloud import S3Path
 from ..cases import BaseTests
 
@@ -37,7 +36,7 @@ class TestUPathS3(BaseTests):
         mock_dir.joinpath("test.txt").touch()
         mock_dir.rmdir()
         assert not mock_dir.exists()
-        with pytest.raises(NotDirectoryError):
+        with pytest.raises(NotADirectoryError):
             self.path.joinpath("file1.txt").rmdir()
 
     def test_relative_to(self):


### PR DESCRIPTION
Hey everyone,

this PR cleans up the `NotDirectoryError` defined in `errors.py` and replaces its usage with `NotADirectoryError`.

Furthermore it corrects the behavior of `.rmdir()` and `.iterdir()` when called on files.
Tests are added and the entire test suite passes.

Cheers,
Andreas :smiley: 