### PR TITLE
Fix upath parents

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 import sys
+from typing import Sequence
 from typing import Union
 import urllib
 from urllib.parse import ParseResult
@@ -447,5 +448,56 @@ class UPath(pathlib.Path):
         if (not name or name[-1] in [self._flavour.sep, self._flavour.altsep]
                 or drv or root or len(parts) != 1):
             raise ValueError("Invalid name %r" % (name))
-        return self._from_parsed_parts(self._drv, self._root,
-                                       self._parts[:-1] + [name], url=self._url)
+        return self._from_parsed_parts(
+            self._drv, self._root, self._parts[:-1] + [name], url=self._url
+        )
+
+    @property
+    def parents(self):
+        """A sequence of this upath's logical parents."""
+        return _UPathParents(self)
+
+
+class _UPathParents(Sequence):
+    """This object provides sequence-like access to the logical ancestors
+    of a path.  Don't try to construct it yourself."""
+
+    __slots__ = (
+        "_pathcls",
+        "_drv",
+        "_root",
+        "_parts",
+        "_url",
+        "_kwargs",
+    )
+
+    def __init__(self, path):
+        # We don't store the instance to avoid reference cycles
+        self._pathcls = type(path)
+        self._drv = path._drv
+        self._root = path._root
+        self._parts = path._parts
+        self._url = path._url
+        self._kwargs = path._kwargs
+
+    def __len__(self):
+        if self._drv or self._root:
+            return len(self._parts) - 1
+        else:
+            return len(self._parts)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return tuple(self[i] for i in range(*idx.indices(len(self))))
+
+        if idx >= len(self) or idx < -len(self):
+            raise IndexError(idx)
+        if idx < 0:
+            idx += len(self)
+        return self._pathcls._from_parsed_parts(
+            self._drv, self._root, self._parts[:-idx - 1], url=self._url, **self._kwargs,
+        )
+
+    def __repr__(self):
+        return "<{}.parents>".format(self._pathcls.__name__)
+

--- a/upath/core.py
+++ b/upath/core.py
@@ -436,20 +436,34 @@ class UPath(pathlib.Path):
         if not old_suffix:
             name = name + suffix
         else:
-            name = name[:-len(old_suffix)] + suffix
-        return self._from_parsed_parts(self._drv, self._root,
-                                       self._parts[:-1] + [name], url=self._url)
+            name = name[: -len(old_suffix)] + suffix
+        return self._from_parsed_parts(
+            self._drv,
+            self._root,
+            self._parts[:-1] + [name],
+            url=self._url,
+            **self._kwargs,
+        )
 
     def with_name(self, name):
         """Return a new path with the file name changed."""
         if not self.name:
             raise ValueError("%r has an empty name" % (self,))
         drv, root, parts = self._flavour.parse_parts((name,))
-        if (not name or name[-1] in [self._flavour.sep, self._flavour.altsep]
-                or drv or root or len(parts) != 1):
+        if (
+            not name
+            or name[-1] in [self._flavour.sep, self._flavour.altsep]
+            or drv
+            or root
+            or len(parts) != 1
+        ):
             raise ValueError("Invalid name %r" % (name))
         return self._from_parsed_parts(
-            self._drv, self._root, self._parts[:-1] + [name], url=self._url
+            self._drv,
+            self._root,
+            self._parts[:-1] + [name],
+            url=self._url,
+            **self._kwargs,
         )
 
     @property
@@ -495,9 +509,12 @@ class _UPathParents(Sequence):
         if idx < 0:
             idx += len(self)
         return self._pathcls._from_parsed_parts(
-            self._drv, self._root, self._parts[:-idx - 1], url=self._url, **self._kwargs,
+            self._drv,
+            self._root,
+            self._parts[: -idx - 1],
+            url=self._url,
+            **self._kwargs,
         )
 
     def __repr__(self):
         return "<{}.parents>".format(self._pathcls.__name__)
-

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -113,6 +113,12 @@ class BaseTests:
         assert set(p.name for p in pl_iter) == set(u.name for u in up_iter)
         assert next(self.path.parent.iterdir()).exists()
 
+    def test_parents(self):
+        p = self.path.joinpath("folder1", "file1.txt")
+        assert p.is_file()
+        assert p.parents[0] == p.parent
+        assert p.parents[1] == p.parent.parent
+
     def test_lchmod(self):
         with pytest.raises(NotImplementedError):
             self.path.lchmod(mode=77)

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -118,6 +118,8 @@ class BaseTests:
         assert p.is_file()
         assert p.parents[0] == p.parent
         assert p.parents[1] == p.parent.parent
+        assert p.parents[0].name == "folder1"
+        assert p.parents[1].name == self.path.name
 
     def test_lchmod(self):
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Hey everyone,

Closes #63 

This PR fixes the `.parents` attribute of `UPath`. Furthermore it fixes a small issue in with_name and with_suffix by providing kwargs to `_format_parsed_parts`.

Cheers,
Andreas :smiley: 