### PR TITLE
Fix s3 path with plus

### DIFF
--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -45,7 +45,7 @@ class CloudPath(upath.core.UPath):
         `listdir` and `glob`. However, in `iterdir` and `glob` we only want the
         relative path to `self`.
         """
-        sp = self.path
+        sp = re.escape(self.path)
         subed = re.sub(f"^({self._url.netloc})?/?({sp}|{sp[1:]})/?", "", name)
         return subed
 


### PR DESCRIPTION
Closes #45 

Hello everyone,

This PR fixes UPath for cloud paths with characters with special meaning in regular expressions (i.e. "+"). Tests are included.

Cheers,
Andreas 😃 
