### PR TITLE
Classmethod format parsed parts

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -505,7 +505,11 @@ class UPath(pathlib.Path):
         cls = type(self)
         return (
             cls,
-            (cls._format_parsed_parts(self._drv, self._root, self._parts, url=self._url),),
+            (
+                cls._format_parsed_parts(
+                    self._drv, self._root, self._parts, url=self._url
+                ),
+            ),
             {"_kwargs": self._kwargs.copy()},
         )
 

--- a/upath/core.py
+++ b/upath/core.py
@@ -92,11 +92,16 @@ class UPath(pathlib.Path):
                 other._drv, other._root, other._parts, drv, root, parts
             )
 
-            new_kwargs = getattr(other, "_kwargs", {}).copy()
+            _kwargs = getattr(other, "_kwargs", {})
+            _url = getattr(other, "_url", None)
+            other_kwargs = _kwargs.copy()
+            if _url:
+                other_kwargs["url"] = _url
+            new_kwargs = _kwargs.copy()
             new_kwargs.update(kwargs)
 
             return other.__class__(
-                other._format_parsed_parts(drv, root, parts),
+                other._format_parsed_parts(drv, root, parts, **other_kwargs),
                 **new_kwargs,
             )
 
@@ -150,16 +155,21 @@ class UPath(pathlib.Path):
             self._drv, self._root, parts, url=self._url, **self._kwargs
         )
 
-    def _format_parsed_parts(self, drv, root, parts):
+    @classmethod
+    def _format_parsed_parts(cls, drv, root, parts, url=None, **kwargs):
         if parts:
             join_parts = parts[1:] if parts[0] == "/" else parts
         else:
             join_parts = []
         if drv or root:
-            path = drv + root + self._flavour.join(join_parts)
+            path = drv + root + cls._flavour.join(join_parts)
         else:
-            path = self._flavour.join(join_parts)
-        scheme, netloc = self._url.scheme, self._url.netloc
+            path = cls._flavour.join(join_parts)
+        if not url:
+            scheme = kwargs.get("scheme", "file")
+            netloc = kwargs.get("netloc")
+        else:
+            scheme, netloc = url.scheme, url.netloc
         scheme = scheme + ":"
         netloc = "//" + netloc if netloc else ""
         formatted = scheme + netloc + path
@@ -449,6 +459,21 @@ class UPath(pathlib.Path):
         obj._root = root
         return obj
 
+    def __str__(self):
+        """Return the string representation of the path, suitable for
+        passing to system calls."""
+        try:
+            return self._str
+        except AttributeError:
+            self._str = self._format_parsed_parts(
+                self._drv,
+                self._root,
+                self._parts,
+                url=self._url,
+                **self._kwargs,
+            )
+            return self._str
+
     @property
     def fs(self):
         return self._accessor._fs
@@ -468,7 +493,7 @@ class UPath(pathlib.Path):
 
         # Create a new object
         out = self.__class__(
-            self._format_parsed_parts(drv, root, parts),
+            self._format_parsed_parts(drv, root, parts, url=self._url),
             **kwargs,
         )
         return out
@@ -477,9 +502,10 @@ class UPath(pathlib.Path):
         self._kwargs = state["_kwargs"].copy()
 
     def __reduce__(self):
+        cls = type(self)
         return (
-            self.__class__,
-            (self._format_parsed_parts(self._drv, self._root, self._parts),),
+            cls,
+            (cls._format_parsed_parts(self._drv, self._root, self._parts, url=self._url),),
             {"_kwargs": self._kwargs.copy()},
         )
 

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -36,7 +36,7 @@ class CloudPath(upath.core.UPath):
         if kwargs.get("bucket") and url is not None:
             bucket = kwargs.pop("bucket")
             url = url._replace(netloc=bucket)
-        obj = super()._from_parsed_parts(drv, root, parts, url, **kwargs)
+        obj = super()._from_parsed_parts(drv, root, parts, url=url, **kwargs)
         return obj
 
     def _sub_path(self, name):

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -38,7 +38,9 @@ class HTTPPath(upath.core.UPath):
         `listdir` and `glob`. However, in `iterdir` and `glob` we only want the
         relative path to `self`.
         """
-        complete_address = self._format_parsed_parts(None, None, [self.path])
+        complete_address = self._format_parsed_parts(
+            None, None, [self.path], url=self._url, **self._kwargs
+        )
 
         if name.startswith(complete_address):
             name = name[len(complete_address) :]  # noqa: E203

--- a/upath/implementations/webdav.py
+++ b/upath/implementations/webdav.py
@@ -38,7 +38,7 @@ class WebdavPath(upath.core.UPath):
         and glob, so we potentially need to sub the whole string
         """
         sp = self.path
-        complete_address = self._format_parsed_parts(None, None, [sp])
+        complete_address = self._format_parsed_parts(None, None, [sp], url=self._url, **self._kwargs)
 
         if name.startswith(complete_address):
             name = name[len(complete_address) :]  # noqa: E203

--- a/upath/implementations/webdav.py
+++ b/upath/implementations/webdav.py
@@ -38,7 +38,9 @@ class WebdavPath(upath.core.UPath):
         and glob, so we potentially need to sub the whole string
         """
         sp = self.path
-        complete_address = self._format_parsed_parts(None, None, [sp], url=self._url, **self._kwargs)
+        complete_address = self._format_parsed_parts(
+            None, None, [sp], url=self._url, **self._kwargs
+        )
 
         if name.startswith(complete_address):
             name = name[len(complete_address) :]  # noqa: E203

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -5,11 +5,12 @@ import sys
 
 import pytest
 from upath import UPath
-from .utils import posixify
 
 
 class BaseTests:
     SUPPORTS_EMPTY_DIRS = True
+
+    path: UPath
 
     def test_cwd(self):
         with pytest.raises(NotImplementedError):
@@ -285,7 +286,7 @@ class BaseTests:
         assert path.fs.storage_options == recovered_path.fs.storage_options
 
     def test_pickling_child_path(self):
-        path = (self.path) / "subfolder" / "subsubfolder"
+        path = self.path / "subfolder" / "subsubfolder"
         pickled_path = pickle.dumps(path)
         recovered_path = pickle.loads(pickled_path)
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -43,11 +43,13 @@ class BaseTests:
         mock_glob = list(self.path.glob("**.txt"))
         path_glob = list(pathlib_base.glob("**/*.txt"))
 
+        _mock_start = len(self.path.parts)
         mock_glob_normalized = sorted(
-            [a.relative_to(self.path).path for a in mock_glob]
+            [a.parts[_mock_start:] for a in mock_glob]
         )
+        _path_start = len(pathlib_base.parts)
         path_glob_normalized = sorted(
-            [f"/{posixify(a.relative_to(pathlib_base))}" for a in path_glob]
+            [a.parts[_path_start:] for a in path_glob]
         )
 
         print(mock_glob_normalized, path_glob_normalized)


### PR DESCRIPTION
Hello everyone,

This PR restores that `UPath._format_parsed_parts` is a `classmethod`, as in `pathlib.Path`.

Once these changes are merged, I can prepare another PR that cleans up the `upath.registry` and start work on supporting chained fsspec filesystems.

Cheers,
Andreas 😃 