### PR TITLE
Lazy registry

### DIFF
--- a/upath/registry.py
+++ b/upath/registry.py
@@ -1,40 +1,72 @@
-from typing import Dict, Type
+import importlib
 import warnings
+from functools import lru_cache
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
-import upath
-from upath.core import UPath
+from fsspec.core import get_filesystem_class
+
+if TYPE_CHECKING:
+    from upath.core import UPath
+
+__all__ = [
+    "get_upath_class",
+]
 
 
 class _Registry:
-    from upath.implementations import cloud, hdfs, http, memory, webdav
-
-    known_implementations: Dict[str, Type[UPath]] = {
-        "abfs": cloud.AzurePath,
-        "adl": cloud.AzurePath,
-        "az": cloud.AzurePath,
-        "gcs": cloud.GCSPath,
-        "gs": cloud.GCSPath,
-        "hdfs": hdfs.HDFSPath,
-        "http": http.HTTPPath,
-        "https": http.HTTPPath,
-        "memory": memory.MemoryPath,
-        "s3": cloud.S3Path,
-        "s3a": cloud.S3Path,
-        "webdav+http": webdav.WebdavPath,
-        "webdav+https": webdav.WebdavPath,
+    known_implementations: "dict[str, type[UPath]]" = {
+        "abfs": "upath.implementations.cloud.AzurePath",
+        "adl": "upath.implementations.cloud.AzurePath",
+        "az": "upath.implementations.cloud.AzurePath",
+        "gcs": "upath.implementations.cloud.GCSPath",
+        "gs": "upath.implementations.cloud.GCSPath",
+        "hdfs": "upath.implementations.hdfs.HDFSPath",
+        "http": "upath.implementations.http.HTTPPath",
+        "https": "upath.implementations.http.HTTPPath",
+        "memory": "upath.implementations.memory.MemoryPath",
+        "s3": "upath.implementations.cloud.S3Path",
+        "s3a": "upath.implementations.cloud.S3Path",
+        "webdav+http": "upath.implementations.webdav.WebdavPath",
+        "webdav+https": "upath.implementations.webdav.WebdavPath",
     }
 
-    def __getitem__(self, item):
-        implementation = self.known_implementations.get(item, None)
-        if not implementation:
-            warning_str = (
-                f"{item} filesystem path not explicitly implemented. "
-                "falling back to default implementation. "
-                "This filesystem may not be tested"
-            )
-            warnings.warn(warning_str, UserWarning)
-            return upath.UPath
-        return implementation
+    def __getitem__(self, item: str) -> "type[UPath] | None":
+        try:
+            fqn = self.known_implementations[item]
+        except KeyError:
+            return None
+        mod, name = fqn.rsplit(".", 1)
+        mod = importlib.import_module(mod)
+        return getattr(mod, name)
 
 
 _registry = _Registry()
+
+_T = TypeVar("_T", bound="UPath")
+
+
+@lru_cache()
+def get_upath_class(protocol: str) -> "type[_T] | None":
+    """return the upath cls for the given protocol"""
+    cls = _registry[protocol]
+    if cls is not None:
+        return cls
+    else:
+        if not protocol:
+            return None  # we want to use pathlib for `None` protocol
+        try:
+            _fs_cls = get_filesystem_class(protocol)
+        except ValueError:
+            return None  # this is an unknown protocol
+        else:
+            if _fs_cls.protocol != "file":
+                warnings.warn(
+                    f"UPath {protocol!r} filesystem not explicitly implemented."
+                    " Falling back to default implementation."
+                    " This filesystem may not be tested.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            mod = importlib.import_module("upath.core")
+            return getattr(mod, "UPath")

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -20,12 +20,18 @@ def test_windows_path(local_testdir):
     assert isinstance(UPath(local_testdir), pathlib.WindowsPath)
 
 
-def test_UPath_warning():
+def test_UPath_untested_protocol_warning():
     with warnings.catch_warnings(record=True) as w:
-        path = UPath("mock:/")  # noqa: F841
+        _ = UPath("mock:/")
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning)
         assert "mock" in str(w[-1].message)
+
+
+def test_UPath_file_protocol_no_warning():
+    with warnings.catch_warnings(record=True) as w:
+        _ = UPath("file:/")
+        assert len(w) == 0
 
 
 class TestUpath(BaseTests):


### PR DESCRIPTION
Hello everyone,

This PR allows to import `upath.registry` without import overhead of implementations and their dependencies. It provides a function `upath.registry.get_upath_class` that takes a protocol, and returns either a specialized implementation of UPath, or the default UPath class if no specialization is available. It returns None if no corresponding fsspec filesystem can be found.

Furthermore, the untested warning for `file:/` protocol UPath instances is removed, since we explicitly test the UPath class with all test cases for the `file` protocol in `test_core.py`.

Cheers,
Andreas 😃 