### PR TITLE
Add type annotations to UPath

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,13 +3,12 @@ on:
   push:
   pull_request:
 jobs:
-  build:
+  tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
         os: [ubuntu-latest, windows-latest]
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -23,9 +22,33 @@ jobs:
     - name: Test with pytest
       run: |
         nox -s smoke
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip nox
     - name: Lint
       run: |
         nox -s lint
+    - name: Type Checking
+      run: |
+        nox -s type_checking
+
+  build:
+    needs: [tests, lint]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip nox
     - name: build package
       run: |
         nox -s build

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,9 +31,12 @@ def install(session):
 def smoke(session):
     if (3, 10) < sys.version_info <= (3, 11, 0, "final"):
         # workaround for missing aiohttp wheels for py3.11
-        session.install("aiohttp", "--no-binary", "aiohttp", env={
-            "AIOHTTP_NO_EXTENSIONS": "1"
-        })
+        session.install(
+            "aiohttp",
+            "--no-binary",
+            "aiohttp",
+            env={"AIOHTTP_NO_EXTENSIONS": "1"},
+        )
 
     session.install(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,12 @@ def lint(session):
 
 
 @nox.session()
+def type_checking(session):
+    session.install("mypy")
+    session.run("mypy", "upath")
+
+
+@nox.session()
 def install(session):
     session.install(".")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,21 @@ include = []
 [tool.black]
 line-length = 80
 target-version = ['py38']
+
+[tool.mypy]
+python_version = "3.7"
+warn_return_any = true
+warn_unused_configs = true
+exclude = "^notebooks|^venv.*|tests.*|^noxfile.py"
+
+[[tool.mypy.overrides]]
+module = "fsspec.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "webdav4.fsspec.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "setuptools.*"
+ignore_missing_imports = true

--- a/upath/core.py
+++ b/upath/core.py
@@ -32,9 +32,7 @@ class _FSSpecAccessor:
     def __init__(self, parsed_url: SplitResult | None, **kwargs: Any) -> None:
         if parsed_url:
             cls = get_filesystem_class(parsed_url.scheme)
-            url_kwargs = cls._get_kwargs_from_urls(
-                urlunsplit(parsed_url)
-            )
+            url_kwargs = cls._get_kwargs_from_urls(urlunsplit(parsed_url))
         else:
             cls = get_filesystem_class(None)
             url_kwargs = {}
@@ -117,7 +115,7 @@ class UPath(pathlib.Path):
             _cls: type[Any] = type(other)
             drv, root, parts = _cls._parse_args(args_list)
             drv, root, parts = _cls._flavour.join_parsed_parts(
-                other._drv, other._root, other._parts, drv, root, parts  # type: ignore
+                other._drv, other._root, other._parts, drv, root, parts  # type: ignore # noqa: E501
             )
 
             _kwargs = getattr(other, "_kwargs", {})
@@ -182,7 +180,14 @@ class UPath(pathlib.Path):
         )
 
     @classmethod
-    def _format_parsed_parts(cls: type[PT], drv: str, root: str, parts: list[str], url: SplitResult | None = None, **kwargs: Any) -> str:
+    def _format_parsed_parts(
+        cls: type[PT],
+        drv: str,
+        root: str,
+        parts: list[str],
+        url: SplitResult | None = None,
+        **kwargs: Any,
+    ) -> str:
         if parts:
             join_parts = parts[1:] if parts[0] == "/" else parts
         else:
@@ -430,7 +435,9 @@ class UPath(pathlib.Path):
                 kwargs[key] = val
         self._accessor.touch(self, truncate=truncate, **kwargs)
 
-    def mkdir(self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False) -> None:
+    def mkdir(
+        self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False
+    ) -> None:
         """
         Create a new directory at this given path.
         """
@@ -453,7 +460,12 @@ class UPath(pathlib.Path):
                     raise
 
     @classmethod
-    def _from_parts(cls: type[PT], args: list[str | PathLike], url: SplitResult | None = None, **kwargs: Any) -> PT:
+    def _from_parts(
+        cls: type[PT],
+        args: list[str | PathLike],
+        url: SplitResult | None = None,
+        **kwargs: Any,
+    ) -> PT:
         obj = object.__new__(cls)
         drv, root, parts = obj._parse_args(args)
         obj._drv = drv
@@ -480,7 +492,7 @@ class UPath(pathlib.Path):
         root: str,
         parts: list[str],
         url: SplitResult | None = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> PT:
         obj = object.__new__(cls)
         obj._drv = drv

--- a/upath/core.py
+++ b/upath/core.py
@@ -258,7 +258,9 @@ class UPath(pathlib.Path):
                     "not of compatible classes."
                 )
             if not isinstance(other_item, str) and (
-                other_item._url.scheme != self._url.scheme
+                self._url is None
+                or other_item._url is None
+                or other_item._url.scheme != self._url.scheme
                 or other_item._url.netloc != self._url.netloc
                 or other_item._kwargs != self._kwargs
             ):

--- a/upath/core.py
+++ b/upath/core.py
@@ -426,6 +426,8 @@ class UPath(pathlib.Path):
         raise NotImplementedError
 
     def touch(self, *args: int, truncate: bool = True, **kwargs) -> None:
+        # Keep the calling signature compatible with Path
+        # (without changing current fsspec behavior for defaults)
         if len(args) > 2:
             raise TypeError("too many arguments")
         else:

--- a/upath/implementations/webdav.py
+++ b/upath/implementations/webdav.py
@@ -1,5 +1,6 @@
 import urllib
 from urllib.parse import ParseResult
+from urllib.parse import urlunsplit
 
 import upath.core
 
@@ -9,11 +10,11 @@ class _WebdavAccessor(upath.core._FSSpecAccessor):
         from webdav4.fsspec import WebdavFileSystem
 
         parsed_url = parsed_url._replace(scheme=parsed_url.scheme[7:], path="")
-        base_url = urllib.parse.urlunparse(parsed_url)
+        base_url = urlunsplit(parsed_url)
         self._fs = WebdavFileSystem(base_url, **kwargs)
 
     def listdir(self, path, **kwargs):
-        base_url = urllib.parse.urlunparse(path._url._replace(path=""))
+        base_url = urlunsplit(path._url._replace(path=""))
         for file_info in self._fs.listdir(
             self._format_path(path).lstrip("/"), **kwargs
         ):
@@ -23,7 +24,7 @@ class _WebdavAccessor(upath.core._FSSpecAccessor):
             }
 
     def glob(self, path, path_pattern, **kwargs):
-        base_url = urllib.parse.urlunparse(path._url._replace(path=""))
+        base_url = urlunsplit(path._url._replace(path=""))
         for file_path in self._fs.glob(
             self._format_path(path_pattern).lstrip("/"), **kwargs
         ):

--- a/upath/implementations/webdav.py
+++ b/upath/implementations/webdav.py
@@ -1,4 +1,3 @@
-import urllib
 from urllib.parse import ParseResult
 from urllib.parse import urlunsplit
 

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -45,7 +45,6 @@ class _Registry:
 _registry = _Registry()
 
 
-
 @lru_cache()
 def get_upath_class(protocol: str) -> type[PT] | None:
     """return the upath cls for the given protocol"""

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import importlib
 import warnings
 from functools import lru_cache
 from typing import TYPE_CHECKING
-from typing import TypeVar
 
 from fsspec.core import get_filesystem_class
 
 if TYPE_CHECKING:
-    from upath.core import UPath
+    from upath.core import PT
 
 __all__ = [
     "get_upath_class",
@@ -15,7 +16,7 @@ __all__ = [
 
 
 class _Registry:
-    known_implementations: "dict[str, type[UPath]]" = {
+    known_implementations: dict[str, str] = {
         "abfs": "upath.implementations.cloud.AzurePath",
         "adl": "upath.implementations.cloud.AzurePath",
         "az": "upath.implementations.cloud.AzurePath",
@@ -31,25 +32,24 @@ class _Registry:
         "webdav+https": "upath.implementations.webdav.WebdavPath",
     }
 
-    def __getitem__(self, item: str) -> "type[UPath] | None":
+    def __getitem__(self, item: str) -> type[PT] | None:
         try:
             fqn = self.known_implementations[item]
         except KeyError:
             return None
-        mod, name = fqn.rsplit(".", 1)
-        mod = importlib.import_module(mod)
-        return getattr(mod, name)
+        module_name, name = fqn.rsplit(".", 1)
+        mod = importlib.import_module(module_name)
+        return getattr(mod, name)  # type: ignore
 
 
 _registry = _Registry()
 
-_T = TypeVar("_T", bound="UPath")
 
 
 @lru_cache()
-def get_upath_class(protocol: str) -> "type[_T] | None":
+def get_upath_class(protocol: str) -> type[PT] | None:
     """return the upath cls for the given protocol"""
-    cls = _registry[protocol]
+    cls: type[PT] | None = _registry[protocol]
     if cls is not None:
         return cls
     else:
@@ -69,4 +69,4 @@ def get_upath_class(protocol: str) -> "type[_T] | None":
                     stacklevel=2,
                 )
             mod = importlib.import_module("upath.core")
-            return getattr(mod, "UPath")
+            return getattr(mod, "UPath")  # type: ignore


### PR DESCRIPTION
This adds type annotations to the UPath class.

Fixes #50 

**Note:**
this PR also switches from `urlparse/urlunparse` to the recommended `urlsplit/urlunsplit`

```console
# repository root
$ python -m venv myvenv
$ . myvenv/bin/activate
$ pip install --upgrade pip
$ pip install mypy .
$ mypy .
Success: no issues found in 11 source files
```

Cheers,
Andreas 😃 