### PR TITLE
Implement `UPath.resolve`

### DIFF
--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -78,4 +78,6 @@ class TestUPathHttp(BaseTests):
         pass
 
     def test_resolve(self):
+        # Also tests following redirects, because the test server issues a 301 redirect 
+        # for `http://127.0.0.1:8080/folder` to `http://127.0.0.1:8080/folder/`
         assert str(self.path.resolve()).endswith("/")

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -78,6 +78,7 @@ class TestUPathHttp(BaseTests):
         pass
 
     def test_resolve(self):
-        # Also tests following redirects, because the test server issues a 301 redirect 
-        # for `http://127.0.0.1:8080/folder` to `http://127.0.0.1:8080/folder/`
+        # Also tests following redirects, because the test server issues a
+        # 301 redirect for `http://127.0.0.1:8080/folder` to
+        # `http://127.0.0.1:8080/folder/`
         assert str(self.path.resolve()).endswith("/")

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -76,3 +76,6 @@ class TestUPathHttp(BaseTests):
 
     def test_fsspec_compat(self):
         pass
+
+    def test_resolve(self):
+        assert str(self.path.resolve()).endswith("/")

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -251,3 +251,11 @@ def test_relative_to():
         UPath("s3://test_bucket/file.txt", anon=True).relative_to(
             UPath("s3://test_bucket", anon=False)
         )
+
+
+def test_uri_parsing():
+    assert (
+        str(UPath("http://www.example.com//a//b/"))
+        == "http://www.example.com//a//b/"
+    )
+

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -259,3 +259,63 @@ def test_uri_parsing():
         == "http://www.example.com//a//b/"
     )
 
+
+NORMALIZATIONS = (
+    ("unnormalized", "normalized"),
+    (
+        # Expected normalization results according to curl
+        ("http://example.com", "http://example.com/"),
+        ("http://example.com/", "http://example.com/"),
+        ("http://example.com/a", "http://example.com/a"),
+        ("http://example.com//a", "http://example.com//a"),
+        ("http://example.com///a", "http://example.com///a"),
+        ("http://example.com////a", "http://example.com////a"),
+        ("http://example.com/a/.", "http://example.com/a/"),
+        ("http://example.com/a/./", "http://example.com/a/"),
+        ("http://example.com/a/./b", "http://example.com/a/b"),
+        ("http://example.com/a/.//", "http://example.com/a//"),
+        ("http://example.com/a/.//b", "http://example.com/a//b"),
+        ("http://example.com/a//.", "http://example.com/a//"),
+        ("http://example.com/a//./", "http://example.com/a//"),
+        ("http://example.com/a//./b", "http://example.com/a//b"),
+        ("http://example.com/a//.//", "http://example.com/a///"),
+        ("http://example.com/a//.//b", "http://example.com/a///b"),
+        ("http://example.com/a/..", "http://example.com/"),
+        ("http://example.com/a/../", "http://example.com/"),
+        ("http://example.com/a/../.", "http://example.com/"),
+        ("http://example.com/a/../..", "http://example.com/"),
+        ("http://example.com/a/../../", "http://example.com/"),
+        ("http://example.com/a/../..//", "http://example.com//"),
+        ("http://example.com/a/..//", "http://example.com//"),
+        ("http://example.com/a/..//.", "http://example.com//"),
+        ("http://example.com/a/..//..", "http://example.com/"),
+        ("http://example.com/a/../b", "http://example.com/b"),
+        ("http://example.com/a/..//b", "http://example.com//b"),
+        ("http://example.com/a//..", "http://example.com/a/"),
+        ("http://example.com/a//../", "http://example.com/a/"),
+        ("http://example.com/a//../.", "http://example.com/a/"),
+        ("http://example.com/a//../..", "http://example.com/"),
+        ("http://example.com/a//../../", "http://example.com/"),
+        ("http://example.com/a//../..//", "http://example.com//"),
+        ("http://example.com/a//..//..", "http://example.com/a/"),
+        ("http://example.com/a//../b", "http://example.com/a/b"),
+        ("http://example.com/a//..//", "http://example.com/a//"),
+        ("http://example.com/a//..//.", "http://example.com/a//"),
+        ("http://example.com/a//..//b", "http://example.com/a//b"),
+        # Normalization with and without an authority component
+        ("memory:/a/b/..", "memory:/a/"),
+        ("memory:/a/b/../..", "memory:/"),
+        ("memory:/a/b/../../..", "memory:/"),
+        ("memory://a/b/..", "memory://a/"),
+        ("memory://a/b/../..", "memory://a/"),
+        ("memory://a/b/../../..", "memory://a/"),
+    ),
+)
+
+
+@pytest.mark.parametrize(*NORMALIZATIONS)
+def test_normalize(unnormalized, normalized):
+    expected = str(UPath(normalized))
+    # Normalise only, do not attempt to follow redirects for http:// paths here
+    result = str(UPath.resolve(UPath(unnormalized)))
+    assert expected == result


### PR DESCRIPTION
Hello,

This PR attempts to fix issues around parsing URI paths (fixes #85), so now URI paths with double and trailing slashes do not get mangled:

```python
>>> UPath("http://www.example.com//page//page/")
... # Previously returned HTTPPath('http://www.example.com/////page/page')
HTTPPath('http://www.example.com//page//page/')
```

It also implements `UPath.resolve`, which normalizes "." and ".." parts in URI paths.

`HTTPPath.resolve` will additionally follow redirects. This is done by sending HEAD requests (if accepted by the server, falling back to GET requests), returning a new `HTTPPath` of the final location.
