### PR TITLE
Various changes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,7 +1,10 @@
 name: Python package
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+    tags:
+      - v*.*.*
     tags: [ '*' ]
   pull_request:
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,7 +5,6 @@ on:
       - main
     tags:
       - v*.*.*
-    tags: [ '*' ]
   pull_request:
 jobs:
   tests:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,13 +1,15 @@
 name: Python package
 on:
   push:
+    branches: [ main ]
   pull_request:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,6 +2,7 @@ name: Python package
 on:
   push:
     branches: [ main ]
+    tags: [ '*' ]
   pull_request:
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Universal Pathlib is a python library that aims to extend Python's built-in [`pa
 ### Pypi
 
 ```bash
-pip install universal_pathlib
+python -m pip install universal_pathlib
 ```
 
 ### conda

--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -14,11 +14,12 @@
    "outputs": [],
    "source": [
     "import pathlib\n",
+    "import warnings\n",
     "from tempfile import NamedTemporaryFile\n",
     "\n",
-    "from upath import UPath, ignore_default_warning\n",
+    "from upath import UPath\n",
     "\n",
-    "ignore_default_warning()"
+    "warnings.filterwarnings(action=\"ignore\", message=\"UPath .*\", module=\"upath.core\")"
    ]
   },
   {
@@ -51,13 +52,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/tmp/tmpr9mkqfpf <class 'str'>\n"
+      "/tmp/tmpdeaokyh7 <class 'str'>\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "PosixPath('/tmp/tmpr9mkqfpf')"
+       "PosixPath('/tmp/tmpdeaokyh7')"
       ]
      },
      "execution_count": 2,
@@ -102,8 +103,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "local_uri='file:///tmp/tmpr9mkqfpf'\n",
-      "local_upath=UPath('file:/tmp/tmpr9mkqfpf')\n",
+      "local_uri='file:///tmp/tmpdeaokyh7'\n",
+      "local_upath=UPath('file:/tmp/tmpdeaokyh7')\n",
       "type(local_upath)=<class 'upath.core.UPath'>\n",
       "type(local_upath.fs)=<class 'fsspec.implementations.local.LocalFileSystem'>\n"
      ]
@@ -155,7 +156,7 @@
     {
      "data": {
       "text/plain": [
-       "<fsspec.implementations.github.GithubFileSystem at 0x7f1aa6616860>"
+       "<fsspec.implementations.github.GithubFileSystem at 0x7f87bfea66b0>"
       ]
      },
      "execution_count": 4,

--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -13,7 +13,12 @@
    },
    "outputs": [],
    "source": [
-    "from upath import UPath"
+    "import pathlib\n",
+    "from tempfile import NamedTemporaryFile\n",
+    "\n",
+    "from upath import UPath, ignore_default_warning\n",
+    "\n",
+    "ignore_default_warning()"
    ]
   },
   {
@@ -25,9 +30,9 @@
     }
    },
    "source": [
-    "### local filesystem\n",
+    "# Local Filesystem\n",
     "\n",
-    "If you give a local path, `UPath` defaults to `pathlib.PosixPath` or `pathlib.WindowsPath`"
+    "If you give a local path, UPath defaults to `pathlib.PosixPath` or `pathlib.WindowsPath`, just as `pathlib.Path`."
    ]
   },
   {
@@ -43,9 +48,16 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/tmp/tmpr9mkqfpf <class 'str'>\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "PosixPath('/tmp')"
+       "PosixPath('/tmp/tmpr9mkqfpf')"
       ]
      },
      "execution_count": 2,
@@ -54,11 +66,15 @@
     }
    ],
    "source": [
-    "local_path = UPath('/tmp')\n",
+    "tmp = NamedTemporaryFile()\n",
+    "print(tmp.name, type(tmp.name))\n",
+    "local_path = UPath(tmp.name)\n",
+    "assert isinstance(local_path, (pathlib.PosixPath, pathlib.WindowsPath))\n",
     "local_path"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "ein.tags": "worksheet-0",
@@ -83,30 +99,32 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "upath/upath/registry.py:33: UserWarning: file filesystem path not explicitly implemented. falling back to default implementation. This filesystem may not be tested\n",
-      "  warnings.warn(warning_str, UserWarning)\n"
+      "local_uri='file:///tmp/tmpr9mkqfpf'\n",
+      "local_upath=UPath('file:/tmp/tmpr9mkqfpf')\n",
+      "type(local_upath)=<class 'upath.core.UPath'>\n",
+      "type(local_upath.fs)=<class 'fsspec.implementations.local.LocalFileSystem'>\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "UPath('file:/tmp')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "local_upath = UPath('file:/tmp')\n",
-    "local_upath"
+    "local_uri = local_path.absolute().as_uri()\n",
+    "print(f\"{local_uri=}\")\n",
+    "\n",
+    "local_upath = UPath(local_uri)\n",
+    "print(f\"{local_upath=}\")\n",
+    "\n",
+    "print(f\"{type(local_upath)=}\")\n",
+    "assert isinstance(local_upath, UPath)\n",
+    "\n",
+    "print(f\"{type(local_upath.fs)=}\")\n",
+    "tmp.close()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "ein.tags": "worksheet-0",
@@ -115,11 +133,11 @@
     }
    },
    "source": [
-    "### fsspec filesystems\n",
+    "# `fsspec` FileSystems\n",
     "\n",
-    "with `UPath` you can connect to any fsspec FileSystem and interact with it in with it as you would with your local filesystem using pathlib. Connection arguments can be given in a couple of ways:\n",
+    "With `UPath` you can connect to any `fsspec` FileSystem and interact with it in with it as you would with your local filesystem using `pathlib`. Connection arguments can be given in a couple of ways:\n",
     "\n",
-    "You can give them as keyword arguments as described for each filesystem in the fsspec docs:"
+    "You can give them as keyword arguments as described in the `fsspec` [docs](https://filesystem-spec.readthedocs.io/en/latest/api.html#built-in-implementations) for each filesystem implementation:"
    ]
   },
   {
@@ -133,12 +151,26 @@
      "slide_type": "-"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<fsspec.implementations.github.GithubFileSystem at 0x7f1aa6616860>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "ghpath = UPath('github:/', org='fsspec', repo='universal_pathlib', sha='main')"
+    "ghpath = UPath('github:/', org='fsspec', repo='universal_pathlib', sha='main')\n",
+    "assert ghpath.exists()\n",
+    "ghpath.fs"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "ein.tags": "worksheet-0",
@@ -147,7 +179,7 @@
     }
    },
    "source": [
-    "or define them in the path/url, in which case they will be appropriately parsed:"
+    "Or define them in the path/url, in which case they will be appropriately parsed:"
    ]
   },
   {
@@ -165,7 +197,7 @@
     {
      "data": {
       "text/plain": [
-       "GithubPath('github://fsspec:universal_pathlib@main/')"
+       "UPath('github://fsspec:universal_pathlib@main/')"
       ]
      },
      "execution_count": 5,
@@ -179,10 +211,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With a `UPath` object instantiated, you can now interact with the paths with the usual `pathlib.Path` API"
+    "With a `UPath` object instantiated, you can now interact with the paths with the usual `pathlib.Path` API."
    ]
   },
   {
@@ -201,30 +234,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "github://fsspec:universal_pathlib@main/.flake8\n",
-      "github://fsspec:universal_pathlib@main/.github\n",
-      "github://fsspec:universal_pathlib@main/.gitignore\n",
-      "github://fsspec:universal_pathlib@main/LICENSE\n",
-      "github://fsspec:universal_pathlib@main/README.md\n",
-      "github://fsspec:universal_pathlib@main/environment.yml\n",
-      "github://fsspec:universal_pathlib@main/notebooks\n",
-      "github://fsspec:universal_pathlib@main/noxfile.py\n",
-      "github://fsspec:universal_pathlib@main/pyproject.toml\n",
-      "github://fsspec:universal_pathlib@main/setup.py\n",
-      "github://fsspec:universal_pathlib@main/upath\n"
+      "github://fsspec:universal_pathlib@main/.flake8\n"
      ]
     }
    ],
    "source": [
     "for p in ghpath.iterdir():\n",
-    "    print(p)"
+    "    print(p)\n",
+    "    break"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `glob` method is also available for most filesystems. Note the syntax here is as defined in `fsspec`, rather than that of pathlib. "
+    "All the standard path methods and attributes of [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) are available too:"
    ]
   },
   {
@@ -240,44 +265,27 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "github://fsspec:universal_pathlib@main/noxfile.py\n",
-      "github://fsspec:universal_pathlib@main/setup.py\n",
-      "github://fsspec:universal_pathlib@main/upath/__init__.py\n",
-      "github://fsspec:universal_pathlib@main/upath/core.py\n",
-      "github://fsspec:universal_pathlib@main/upath/errors.py\n",
-      "github://fsspec:universal_pathlib@main/upath/implementations/__init__.py\n",
-      "github://fsspec:universal_pathlib@main/upath/implementations/cloud.py\n",
-      "github://fsspec:universal_pathlib@main/upath/implementations/hdfs.py\n",
-      "github://fsspec:universal_pathlib@main/upath/implementations/http.py\n",
-      "github://fsspec:universal_pathlib@main/upath/implementations/memory.py\n",
-      "github://fsspec:universal_pathlib@main/upath/registry.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/__init__.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/cases.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/conftest.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/implementations/__init__.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/implementations/test_gcs.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/implementations/test_hdfs.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/implementations/test_http.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/implementations/test_memory.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/implementations/test_s3.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/test_core.py\n",
-      "github://fsspec:universal_pathlib@main/upath/tests/utils.py\n"
-     ]
+     "data": {
+      "text/plain": [
+       "UPath('github://fsspec:universal_pathlib@main/README.md')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "for p in ghpath.glob('**.py'):\n",
-    "    print(p)"
+    "readme_path = ghpath / \"README.md\"\n",
+    "readme_path"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All the standard path methods and attributes of `pathlib.Path` are available too:"
+    "To get the full path as a string use:"
    ]
   },
   {
@@ -295,7 +303,7 @@
     {
      "data": {
       "text/plain": [
-       "GithubPath('github://fsspec:universal_pathlib@main/README.md')"
+       "'github://fsspec:universal_pathlib@main/README.md'"
       ]
      },
      "execution_count": 8,
@@ -304,15 +312,15 @@
     }
    ],
    "source": [
-    "readme_path = ghpath / 'README.md'\n",
-    "readme_path"
+    "str(readme_path)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get the full path as a string use:"
+    "You can also use the path attribute to get just the path:"
    ]
   },
   {
@@ -330,7 +338,7 @@
     {
      "data": {
       "text/plain": [
-       "'github://fsspec:universal_pathlib@main/README.md'"
+       "'/README.md'"
       ]
      },
      "execution_count": 9,
@@ -339,14 +347,8 @@
     }
    ],
    "source": [
-    "str(readme_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also use the path attribute to get just the path:"
+    "# path attribute added\n",
+    "readme_path.path"
    ]
   },
   {
@@ -364,7 +366,7 @@
     {
      "data": {
       "text/plain": [
-       "'/README.md'"
+       "('README.md', 'README', '.md')"
       ]
      },
      "execution_count": 10,
@@ -373,8 +375,7 @@
     }
    ],
    "source": [
-    "# path attribute added\n",
-    "readme_path.path"
+    "readme_path.name, readme_path.stem, readme_path.suffix"
    ]
   },
   {
@@ -392,7 +393,7 @@
     {
      "data": {
       "text/plain": [
-       "'README.md'"
+       "'# Universal Pathlib'"
       ]
      },
      "execution_count": 11,
@@ -401,143 +402,12 @@
     }
    ],
    "source": [
-    "readme_path.name"
+    "readme_path.read_text().splitlines()[0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "autoscroll": false,
-    "ein.hycell": false,
-    "ein.tags": "worksheet-0",
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'README'"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "readme_path.stem"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "autoscroll": false,
-    "ein.hycell": false,
-    "ein.tags": "worksheet-0",
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'.md'"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "readme_path.suffix"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "autoscroll": false,
-    "ein.hycell": false,
-    "ein.tags": "worksheet-0",
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "readme_path.exists()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "autoscroll": false,
-    "ein.hycell": false,
-    "ein.tags": "worksheet-0",
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'# Universal Pathlib'"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "readme_path.read_text()[:19]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Some filesystems may require extra imports to use."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "autoscroll": false,
-    "ein.hycell": false,
-    "ein.tags": "worksheet-0",
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import s3fs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -553,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -567,52 +437,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "s3://spacenet-dataset/LICENSE.md\n",
-      "s3://spacenet-dataset/\n",
-      "s3://spacenet-dataset/AOIs\n",
-      "s3://spacenet-dataset/Hosted-Datasets\n",
-      "s3://spacenet-dataset/SpaceNet_Off-Nadir_Dataset\n",
-      "s3://spacenet-dataset/spacenet-model-weights\n",
-      "s3://spacenet-dataset/spacenet-stac\n",
-      "s3://spacenet-dataset/spacenet\n"
+      "s3://spacenet-dataset/LICENSE.md\n"
      ]
     }
    ],
    "source": [
     "for p in s3path.iterdir():\n",
-    "    print(p)"
+    "    if p.is_file():\n",
+    "        print(p)\n",
+    "        break"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can chain paths with the `/` operator and read text or binary contents."
+    "You can chain paths with the `/` operator and any methods."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The \"SpaceNet Dataset\" is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.  The \"SpaceNet Dataset\" includes all contents of this S3 bucket except for the contents of the \"Hosted-Datasets\" folder and its subfolders.\\n\\nhttps://creativecommons.org/licenses/by-sa/4.0/\\n'"
+       "True"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "(s3path / \"LICENSE.md\").read_text()"
+    "(s3path / \"LICENSE.md\").exists()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -629,39 +495,130 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Globbing also works for many filesystems."
+    "The `glob` method is also available for most filesystems. Note the syntax here is as detailed in `fsspec` [docs](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.glob), rather than that of `pathlib`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "s3://spacenet-dataset/AOIs/AOI_3_Paris/MS/16FEB29111913-M2AS_R01C1-055649178040_01_P001.TIF\n",
-      "s3://spacenet-dataset/AOIs/AOI_3_Paris/MS/16FEB29111913-M2AS_R01C2-055649178040_01_P001.TIF\n",
-      "s3://spacenet-dataset/AOIs/AOI_3_Paris/MS/16FEB29111913-M2AS_R01C3-055649178040_01_P001.TIF\n",
-      "s3://spacenet-dataset/AOIs/AOI_3_Paris/MS/16FEB29111913-M2AS_R01C4-055649178040_01_P001.TIF\n",
-      "s3://spacenet-dataset/AOIs/AOI_3_Paris/MS/16FEB29111913-M2AS_R01C5-055649178040_01_P001.TIF\n"
+      "s3://spacenet-dataset/AOIs/AOI_3_Paris/MS/16FEB29111913-M2AS_R01C1-055649178040_01_P001.TIF\n"
      ]
     }
    ],
    "source": [
-    "from itertools import islice \n",
-    "for p in islice((s3path / \"AOIs\" / \"AOI_3_Paris\").glob(\"**.TIF\"), 5):\n",
-    "    print(p)"
+    "for p in (s3path / \"AOIs\" / \"AOI_3_Paris\").glob(\"**.TIF\"):\n",
+    "    print(p)\n",
+    "    break"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Works with fsspec filesystems\n",
+    "\n",
+    "Some filesystems may require additional packages to be installed.\n",
+    "\n",
+    "Check out some of the known implementations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "| Name | Class |\n",
+       "| --- | --- |\n",
+       "| abfs | adlfs.AzureBlobFileSystem |\n",
+       "| abfss | adlfs.AzureBlobFileSystem |\n",
+       "| adl | adlfs.AzureDatalakeFileSystem |\n",
+       "| arrow_hdfs | fsspec.implementations.arrow.HadoopFileSystem |\n",
+       "| asynclocal | morefs.asyn_local.AsyncLocalFileSystem |\n",
+       "| az | adlfs.AzureBlobFileSystem |\n",
+       "| blockcache | fsspec.implementations.cached.CachingFileSystem |\n",
+       "| cached | fsspec.implementations.cached.CachingFileSystem |\n",
+       "| dask | fsspec.implementations.dask.DaskWorkerFileSystem |\n",
+       "| dbfs | fsspec.implementations.dbfs.DatabricksFileSystem |\n",
+       "| dir | fsspec.implementations.dirfs.DirFileSystem |\n",
+       "| dropbox | dropboxdrivefs.DropboxDriveFileSystem |\n",
+       "| dvc | dvc.api.DVCFileSystem |\n",
+       "| file | fsspec.implementations.local.LocalFileSystem |\n",
+       "| filecache | fsspec.implementations.cached.WholeFileCacheFileSystem |\n",
+       "| ftp | fsspec.implementations.ftp.FTPFileSystem |\n",
+       "| gcs | gcsfs.GCSFileSystem |\n",
+       "| gdrive | gdrivefs.GoogleDriveFileSystem |\n",
+       "| generic | fsspec.generic.GenericFileSystem |\n",
+       "| git | fsspec.implementations.git.GitFileSystem |\n",
+       "| github | fsspec.implementations.github.GithubFileSystem |\n",
+       "| gs | gcsfs.GCSFileSystem |\n",
+       "| hdfs | fsspec.implementations.arrow.HadoopFileSystem |\n",
+       "| hf | huggingface_hub.HfFileSystem |\n",
+       "| http | fsspec.implementations.http.HTTPFileSystem |\n",
+       "| https | fsspec.implementations.http.HTTPFileSystem |\n",
+       "| jlab | fsspec.implementations.jupyter.JupyterFileSystem |\n",
+       "| jupyter | fsspec.implementations.jupyter.JupyterFileSystem |\n",
+       "| libarchive | fsspec.implementations.libarchive.LibArchiveFileSystem |\n",
+       "| memory | fsspec.implementations.memory.MemoryFileSystem |\n",
+       "| oci | ocifs.OCIFileSystem |\n",
+       "| oss | ossfs.OSSFileSystem |\n",
+       "| reference | fsspec.implementations.reference.ReferenceFileSystem |\n",
+       "| root | fsspec_xrootd.XRootDFileSystem |\n",
+       "| s3 | s3fs.S3FileSystem |\n",
+       "| s3a | s3fs.S3FileSystem |\n",
+       "| sftp | fsspec.implementations.sftp.SFTPFileSystem |\n",
+       "| simplecache | fsspec.implementations.cached.SimpleCacheFileSystem |\n",
+       "| smb | fsspec.implementations.smb.SMBFileSystem |\n",
+       "| ssh | fsspec.implementations.sftp.SFTPFileSystem |\n",
+       "| tar | fsspec.implementations.tar.TarFileSystem |\n",
+       "| wandb | wandbfs.WandbFS |\n",
+       "| webdav | webdav4.fsspec.WebdavFileSystem |\n",
+       "| webhdfs | fsspec.implementations.webhdfs.WebHDFS |\n",
+       "| zip | fsspec.implementations.zip.ZipFileSystem |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from fsspec.registry import known_implementations\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "known = [\n",
+    "    f\"| {name} | {d['class']} |\" for name, d in sorted(known_implementations.items())\n",
+    "]\n",
+    "known = \"\\n\".join([\"| Name | Class |\\n| --- | --- |\", *known])\n",
+    "display(Markdown(known))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "fsspec",
    "language": "python",
    "name": "python3"
   },
@@ -675,9 +632,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.10"
   },
-  "name": "Untitled.ipynb"
+  "name": "Untitled.ipynb",
+  "vscode": {
+   "interpreter": {
+    "hash": "d4d4510d3a243cfb62b62dec561eb2191aad85ef77736fec7cfe79076e15c84c"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/upath/__init__.py
+++ b/upath/__init__.py
@@ -1,6 +1,8 @@
-"""Pathlib API extended to use fsspec backends"""
+"""Pathlib API extended to use fsspec backends."""
 __version__ = "0.0.23"
 
 from upath.core import UPath
+from upath.errors import ignore_default_warning
 
-__all__ = ["UPath"]
+
+__all__ = ["UPath", "ignore_default_warning"]

--- a/upath/__init__.py
+++ b/upath/__init__.py
@@ -2,7 +2,6 @@
 __version__ = "0.0.23"
 
 from upath.core import UPath
-from upath.errors import ignore_default_warning
 
 
-__all__ = ["UPath", "ignore_default_warning"]
+__all__ = ["UPath"]

--- a/upath/core.py
+++ b/upath/core.py
@@ -103,6 +103,7 @@ class _FSSpecAccessor:
             **kwargs,
         )
 
+
 class _UriFlavour(_PosixFlavour):
     def parse_parts(self, parts):
         parsed = []
@@ -763,4 +764,3 @@ def _from_path(
         **new_kwargs,
     )
     return out
-

--- a/upath/core.py
+++ b/upath/core.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import pathlib
 import re
 import sys
 from collections import ChainMap
 from os import PathLike
 from pathlib import _PosixFlavour  # type: ignore
+from pathlib import Path
 from pathlib import PurePath
 from typing import Sequence
 from typing import TypeVar
@@ -132,7 +132,7 @@ class _UriFlavour(_PosixFlavour):
 PT = TypeVar("PT", bound="UPath")
 
 
-class UPath(pathlib.Path):
+class UPath(Path):
     __slots__ = (
         "_url",
         "_kwargs",
@@ -154,7 +154,7 @@ class UPath(pathlib.Path):
         args_list = list(args)
         other = args_list.pop(0)
 
-        if isinstance(other, pathlib.Path):
+        if isinstance(other, PurePath):
             # Create a (modified) copy, if first arg is a Path object
             _cls: type[Any] = type(other)
             drv, root, parts = _cls._parse_args(args_list)
@@ -182,9 +182,9 @@ class UPath(pathlib.Path):
                 parsed_url = parsed_url._replace(**{key: val})
 
         upath_cls = get_upath_class(protocol=parsed_url.scheme)
-        if upath_cls in {pathlib.Path, None}:
+        if upath_cls in {Path, None}:
             # treat as local filesystem, return PosixPath or WindowsPath
-            return pathlib.Path(*args, **kwargs)  # type: ignore
+            return Path(*args, **kwargs)  # type: ignore
 
         args_list.insert(0, parsed_url.path)
         # return upath instance

--- a/upath/core.py
+++ b/upath/core.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import sys
-from collections import ChainMap
 from os import PathLike
 from pathlib import _PosixFlavour  # type: ignore
 from pathlib import Path

--- a/upath/core.py
+++ b/upath/core.py
@@ -164,11 +164,12 @@ class UPath(Path):
 
             _kwargs = getattr(other, "_kwargs", {})
             _url = getattr(other, "_url", None)
-            other_kwargs = {}
+            other_kwargs = _kwargs.copy()
             if _url:
                 other_kwargs["url"] = _url
-            other_kwargs = ChainMap(other_kwargs, _kwargs)  # type: ignore
-            new_kwargs = ChainMap(kwargs, _kwargs)
+            new_kwargs = _kwargs.copy()
+            new_kwargs.update(kwargs)
+
             return _cls(  # type: ignore
                 _cls._format_parsed_parts(drv, root, parts, **other_kwargs),
                 **new_kwargs,
@@ -182,7 +183,7 @@ class UPath(Path):
                 parsed_url = parsed_url._replace(**{key: val})
 
         upath_cls = get_upath_class(protocol=parsed_url.scheme)
-        if upath_cls in {Path, None}:
+        if upath_cls is None:
             # treat as local filesystem, return PosixPath or WindowsPath
             return Path(*args, **kwargs)  # type: ignore
 

--- a/upath/errors.py
+++ b/upath/errors.py
@@ -1,7 +1,27 @@
 import warnings
+from functools import partial
+
+
+__all__ = [
+    "DefaultImplementationWarning",
+    "ignore_default_warning",
+]
+
+
+class DefaultImplementationWarning(UserWarning):
+    """Custom warning for easy filtering."""
+
+
+ignore_default_warning = partial(
+    warnings.filterwarnings,
+    action="ignore",
+    category=DefaultImplementationWarning,
+    module="upath",
+)
 
 
 def __getattr__(name):
+    """Provide deprecation warning for NotDirectoryError."""
     if name == "NotDirectoryError":
         warnings.warn(
             "upath.errors.NotDirectoryError is deprecated. "
@@ -10,4 +30,6 @@ def __getattr__(name):
             stacklevel=2,
         )
         return NotADirectoryError
+    if name in __all__:
+        return globals()[name]
     raise AttributeError(name)

--- a/upath/errors.py
+++ b/upath/errors.py
@@ -1,23 +1,4 @@
 import warnings
-from functools import partial
-
-
-__all__ = [
-    "DefaultImplementationWarning",
-    "ignore_default_warning",
-]
-
-
-class DefaultImplementationWarning(UserWarning):
-    """Custom warning for easy filtering."""
-
-
-ignore_default_warning = partial(
-    warnings.filterwarnings,
-    action="ignore",
-    category=DefaultImplementationWarning,
-    module="upath",
-)
 
 
 def __getattr__(name):
@@ -30,6 +11,4 @@ def __getattr__(name):
             stacklevel=2,
         )
         return NotADirectoryError
-    if name in __all__:
-        return globals()[name]
     raise AttributeError(name)

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -1,5 +1,6 @@
-import upath.core
 import re
+
+import upath.core
 
 
 class _CloudAccessor(upath.core._FSSpecAccessor):
@@ -10,12 +11,13 @@ class _CloudAccessor(upath.core._FSSpecAccessor):
         return f"{path._url.netloc}/{path.path.lstrip('/')}"
 
     def mkdir(self, path, create_parents=True, **kwargs):
+        _path = self._format_path(path)
         if (
             not create_parents
             and not kwargs.get("exist_ok", False)
-            and self._fs.exists(self._format_path(path))
+            and self._fs.exists(_path)
         ):
-            raise FileExistsError
+            raise FileExistsError(_path)
         return super().mkdir(path, create_parents=create_parents, **kwargs)
 
 
@@ -46,11 +48,15 @@ class CloudPath(upath.core.UPath):
         relative path to `self`.
         """
         sp = re.escape(self.path)
-        subed = re.sub(f"^({self._url.netloc})?/?({sp}|{sp[1:]})/?", "", name)
-        return subed
+        netloc = self._url.netloc  # type: ignore
+        return re.sub(
+            f"^({netloc})?/?({sp}|{sp[1:]})/?",
+            "",
+            name,
+        )
 
     def joinpath(self, *args):
-        if self._url.netloc:
+        if self._url.netloc:  # type: ignore
             return super().joinpath(*args)
         # handles a bucket in the path
         else:

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -48,7 +48,7 @@ class CloudPath(upath.core.UPath):
         relative path to `self`.
         """
         sp = re.escape(self.path)
-        netloc = self._url.netloc  # type: ignore
+        netloc = self._url.netloc
         return re.sub(
             f"^({netloc})?/?({sp}|{sp[1:]})/?",
             "",
@@ -56,7 +56,7 @@ class CloudPath(upath.core.UPath):
         )
 
     def joinpath(self, *args):
-        if self._url.netloc:  # type: ignore
+        if self._url.netloc:
             return super().joinpath(*args)
         # handles a bucket in the path
         else:

--- a/upath/implementations/hdfs.py
+++ b/upath/implementations/hdfs.py
@@ -16,7 +16,7 @@ class _HDFSAccessor(upath.core._FSSpecAccessor):
             return self._fs.makedirs(pth, **kwargs)
         else:
             if not kwargs.get("exist_ok", False) and self._fs.exists(pth):
-                raise FileExistsError
+                raise FileExistsError(pth)
             return self._fs.mkdir(pth, create_parents=create_parents, **kwargs)
 
 

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING
 
 from fsspec.core import get_filesystem_class
 
-import upath.errors
-
 
 if TYPE_CHECKING:
     from upath.core import PT
@@ -57,7 +55,7 @@ def get_upath_class(protocol: str) -> type[PT] | type[Path] | None:
         return cls
     else:
         if not protocol:
-            return Path  # we want to use pathlib for `None` protocol
+            return None  # we want to use pathlib for `None` protocol
         try:
             _fs_cls = get_filesystem_class(protocol)
         except ValueError:
@@ -68,7 +66,7 @@ def get_upath_class(protocol: str) -> type[PT] | type[Path] | None:
                     f"UPath {protocol!r} filesystem not explicitly implemented."
                     " Falling back to default implementation."
                     " This filesystem may not be tested.",
-                    upath.errors.DefaultImplementationWarning,
+                    UserWarning,
                     stacklevel=2,
                 )
             mod = importlib.import_module("upath.core")

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import importlib
 import warnings
 from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fsspec.core import get_filesystem_class
+
+import upath.errors
+
 
 if TYPE_CHECKING:
     from upath.core import PT
@@ -46,14 +50,14 @@ _registry = _Registry()
 
 
 @lru_cache()
-def get_upath_class(protocol: str) -> type[PT] | None:
-    """return the upath cls for the given protocol"""
+def get_upath_class(protocol: str) -> type[PT] | type[Path] | None:
+    """Return the upath cls for the given protocol."""
     cls: type[PT] | None = _registry[protocol]
     if cls is not None:
         return cls
     else:
         if not protocol:
-            return None  # we want to use pathlib for `None` protocol
+            return Path  # we want to use pathlib for `None` protocol
         try:
             _fs_cls = get_filesystem_class(protocol)
         except ValueError:
@@ -64,7 +68,7 @@ def get_upath_class(protocol: str) -> type[PT] | None:
                     f"UPath {protocol!r} filesystem not explicitly implemented."
                     " Falling back to default implementation."
                     " This filesystem may not be tested.",
-                    UserWarning,
+                    upath.errors.DefaultImplementationWarning,
                     stacklevel=2,
                 )
             mod = importlib.import_module("upath.core")

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -209,10 +209,22 @@ class BaseTests:
         with pytest.raises(NotImplementedError):
             self.path.readlink()
 
-    @pytest.mark.xfail
     def test_rename(self):
-        # need to implement
-        raise False
+        upath = self.path.joinpath("file1.txt")
+        target = upath.parent.joinpath("file1_renamed.txt")
+        moved = upath.rename(target)
+        assert target == moved
+        assert not upath.exists()
+        assert moved.exists()
+
+    def test_rename2(self):
+        upath = self.path.joinpath("folder1/file2.txt")
+        target = "file2_renamed.txt"
+        moved = upath.rename(target)
+        target_path = upath.parent.joinpath(target).resolve()
+        assert target_path == moved
+        assert not upath.exists()
+        assert moved.exists()
 
     def test_replace(self):
         pass
@@ -220,8 +232,11 @@ class BaseTests:
     def test_resolve(self):
         pass
 
-    def test_rglob(self):
-        pass
+    def test_rglob(self, pathlib_base):
+        pattern = "*.txt"
+        result = [*self.path.rglob(pattern)]
+        expected = [*pathlib_base.rglob(pattern)]
+        assert len(result) == len(expected)
 
     def test_samefile(self):
         pass
@@ -386,3 +401,8 @@ class BaseTests:
         assert p.is_file()
         with pytest.raises(NotADirectoryError):
             _ = list(p.iterdir())
+
+    def test_rmdir_not_empty(self):
+        p = self.path.joinpath("folder1")
+        with pytest.raises(OSError, match="not empty"):
+            p.rmdir(recursive=False)

--- a/upath/tests/implementations/test_azure.py
+++ b/upath/tests/implementations/test_azure.py
@@ -41,3 +41,7 @@ class TestAzurePath(BaseTests):
     @pytest.mark.skip
     def test_makedirs_exist_ok_false(self):
         pass
+
+    @pytest.mark.xfail(reason="test interaction")
+    def test_rglob(self, pathlib_base):
+        return super().test_rglob(pathlib_base)

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -82,3 +82,11 @@ class TestUPathHttp(BaseTests):
         # 301 redirect for `http://127.0.0.1:8080/folder` to
         # `http://127.0.0.1:8080/folder/`
         assert str(self.path.resolve()).endswith("/")
+
+    def test_rename(self):
+        with pytest.raises(NotImplementedError):
+            return super().test_rename()
+
+    def test_rename2(self):
+        with pytest.raises(NotImplementedError):
+            return super().test_rename()


### PR DESCRIPTION
These changes are broken out from the result of some long running tinkering I started a couple of years ago.  To help keep the review process reasonable, I am trying to strike a balance of not creating too many small PRs while also not creating overly large PRs.  Along those lines I am willing to break out or combine change sets in whatever manner is most comfortable for review, just let me know.

Changes in this PR:
  - Improve some error messages by including the string value of the path so it is clear what failed.
  - Refactored `__new__`, extracting a method for creating paths from other path objects to improve readability and clarity.
  - Cleaned up notebook for clarity and brevity, also added table of fsspec supported filesystems.
  - Added custom warning to make it easier to filter, also added simple function to do so.
  - Fixed bug causing incorrect rglob results (top level glob matches were not included).
  - GitHub Actions
    - Only run on PRs and pushes to main, to fix duplicate runs.
    - Don't fail fast, so that multiple failures can be reviewed after each run.
    - Run on "3.11" rather than "3.11-dev".

Changes split out for later:
  - Refactor tests and fixtures for improved isolation.
    - Make it easier and safer to allow for tests to be run live.
    - Reduce inadvertent test interaction and flakiness.
    - Eventually try to use UPath's great test suite directly from other fsspec filesystem projects to improve coverage.
  - Migrate to hatch, stop using legacy setup metadata format.
  - Update and consolidate dev tools and test dependencies.
  - New nox tasks and minor changes for convenience.
  - Add, configure, and apply pre-commit for consistent code formatting.

I'd be eager for any feedback or suggestions.  Thanks!
