### PR TITLE
Copy url params in format_parsed_parts

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -9,6 +9,8 @@ from pathlib import PurePath
 from typing import Sequence
 from typing import TypeVar
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl
+from urllib.parse import urlencode
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
@@ -245,6 +247,18 @@ class UPath(Path):
         scheme = scheme + ":"
         netloc = "//" + netloc if netloc else ""
         formatted = scheme + netloc + path
+        if url and url.query:
+            formatted_url = urlsplit(formatted, scheme=scheme)
+            new_query = parse_qsl(url.query) + parse_qsl(formatted_url.query)
+            formatted = urlunsplit(
+                (
+                    formatted_url.scheme,
+                    formatted_url.netloc,
+                    formatted_url.path,
+                    urlencode(new_query),
+                    formatted_url.fragment,
+                )
+            )
         return formatted
 
     @property

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -406,3 +406,12 @@ class BaseTests:
         p = self.path.joinpath("folder1")
         with pytest.raises(OSError, match="not empty"):
             p.rmdir(recursive=False)
+
+    def test_joinpath_copies_url_params(self):
+        query = "param1=value1"
+        path1 = self.path / f"test_joinpath_dir1?{query}"
+        assert path1._url.query == query
+        path2 = path1 / "file1.txt"
+        assert path2._url.query == query
+        path3 = path1 / "file2.txt?param2=value2"
+        assert path3._url.query == "param1=value1&param2=value2"


### PR DESCRIPTION
Similar to #95 I noticed that when creating sub-paths using `/` or `__truediv__` we are not copying the `url` params. 

Example,
```py
>>> from upath import UPath
>>> base = UPath("s3://bucket/dir?param1=value1")
>>> base._url
SplitResult(scheme='s3', netloc='bucket', path='/dir', query='param1=value1', fragment='')
>>> file = base / "file1.txt"
>>> file._url
SplitResult(scheme='s3', netloc='bucket', path='/dir/file1.txt', query='', fragment='')
```

This PR attempts to resolve this by copying the query parameters when creating sub-paths using `/`.

Results with the fix,
```py
>>> from upath import UPath
>>> base = UPath("s3://bucket/dir?param1=value1")
>>> base._url
SplitResult(scheme='s3', netloc='bucket', path='/dir', query='param1=value1', fragment='')
>>> file = base / "file1.txt"
>>> file._url
SplitResult(scheme='s3', netloc='bucket', path='/dir/file1.txt', query='param1=value1', fragment='')
```