### PR TITLE
Add support for abfss protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more examples, see the [example notebook here](notebooks/examples.ipynb)
 
 - `file:` Local filessystem
 - `memory:` Ephemeral filesystem in RAM
-- `az:`, `adl:` and `abfs:` Azure Storage (requires `adlfs` to be installed)
+- `az:`, `adl:`, `abfs:` and `abfss:` Azure Storage (requires `adlfs` to be installed)
 - `http:` and `https:` HTTP(S)-based filesystem
 - `hdfs:` Hadoop distributed filesystem
 - `gs:` and `gcs:` Google Cloud Storage (requires `gcsfs` to be installed)

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -19,6 +19,7 @@ __all__ = [
 class _Registry:
     known_implementations: dict[str, str] = {
         "abfs": "upath.implementations.cloud.AzurePath",
+        "abfss": "upath.implementations.cloud.AzurePath",
         "adl": "upath.implementations.cloud.AzurePath",
         "az": "upath.implementations.cloud.AzurePath",
         "gcs": "upath.implementations.cloud.GCSPath",


### PR DESCRIPTION
Hi,

`abfss` protocol is supported by `adlfs` and, from my tests, seems to work just fine with `universal_pathlib`.
Would it be possible to add it to the list of supported protocols?