### PR TITLE
Add storage options and protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,29 @@ If a local path is provided, `UPath` will return a `PosixUPath` or `WindowsUPath
 These two subclasses are 100% compatible with the `PosixPath` and `WindowsPath` classes of their
 specific Python version, and are tested against all relevant tests of the CPython pathlib test-suite.
 
+### UPath public class API
+
+`UPath`'s public class interface is identical to `pathlib.Path` with the addition of the following attributes:
+
+- `UPath(...).protocol: str` the filesystem_spec protocol _(note: for `PosixUPath` and `WindowsUPath` it's an empty string)_
+- `UPath(...).storage_options: dict[str, Any]` the storage options for instantiating the filesystem_spec class
+- `UPath(...).path: str` the filesystem_spec compatible path for use with filesystem instances
+- `UPath(...).fs: AbstractFileSystem` convenience attribute to access an instantiated filesystem
+
+the first three provide a public interface to access a file via fsspec as follows:
+
+```python
+from upath import UPath
+from fsspec import filesystem
+
+p = UPath("s3://bucket/file.txt", anon=True)
+
+fs = filesystem(p.protocol, **p.storage_options)  # equivalent to p.fs
+with fs.open(p.path) as f:
+    data = f.read()
+```
+
+
 ## Contributing
 
 Contributions are very welcome.

--- a/upath/core.py
+++ b/upath/core.py
@@ -214,6 +214,8 @@ class UPath(Path):
         is backed by fsspec or '' if it's backed by stdlib pathlib. For
         both `fsspec.get_filesystem_class` returns `LocalFileSystem`.
         """
+        if self._url is None:
+            return ""
         return self._url.scheme
 
     @property

--- a/upath/core.py
+++ b/upath/core.py
@@ -44,7 +44,7 @@ class _FSSpecAccessor:
         self._fs = cls(**url_kwargs)
 
     def _format_path(self, path: UPath) -> str:
-        return path.path
+        return path._path
 
     def open(self, path, mode="r", *args, **kwargs):
         return self._fs.open(self._format_path(path), mode, *args, **kwargs)
@@ -240,12 +240,7 @@ class UPath(Path):
 
         Note: for some file systems this can be prefixed by the protocol.
         """
-        if self._parts:
-            join_parts = self._parts[1:] if self._parts[0] == "/" else self._parts
-            path: str = self._flavour.join(join_parts)
-            return self._root + path
-        else:
-            return "/"
+        return self._path
 
     def __getattr__(self, item: str) -> Any:
         if item == "_accessor":
@@ -297,6 +292,15 @@ class UPath(Path):
         netloc = "//" + netloc if netloc else ""
         formatted = scheme + netloc + path
         return formatted
+
+    @property
+    def _path(self) -> str:
+        if self._parts:
+            join_parts = self._parts[1:] if self._parts[0] == "/" else self._parts
+            path: str = self._flavour.join(join_parts)
+            return self._root + path
+        else:
+            return "/"
 
     def open(self, *args, **kwargs):
         return self._accessor.open(self, *args, **kwargs)
@@ -381,7 +385,7 @@ class UPath(Path):
 
     def _sub_path(self, name):
         # only want the path name with iterdir
-        sp = self.path
+        sp = self._path
         return re.sub(f"^({sp}|{sp[1:]})/", "", name)
 
     def absolute(self: PT) -> PT:

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -10,7 +10,7 @@ class _CloudAccessor(upath.core._FSSpecAccessor):
         """
         netloc has already been set to project via `CloudPath._from_parts`
         """
-        return f"{path._url.netloc}/{path.path.lstrip('/')}"
+        return f"{path._url.netloc}/{path._path.lstrip('/')}"
 
     def mkdir(self, path, create_parents=True, **kwargs):
         _path = self._format_path(path)
@@ -49,7 +49,7 @@ class CloudPath(upath.core.UPath):
         `listdir` and `glob`. However, in `iterdir` and `glob` we only want the
         relative path to `self`.
         """
-        sp = re.escape(self.path)
+        sp = re.escape(self._path)
         netloc = self._url.netloc
         return re.sub(
             f"^({netloc})?/?({sp}|{sp[1:]})/?",
@@ -70,6 +70,10 @@ class CloudPath(upath.core.UPath):
             bucket = args_list.pop(0)
             self._kwargs["bucket"] = bucket
             return super().joinpath(*tuple(args_list))
+
+    @property
+    def path(self) -> str:
+        return f"{self._url.netloc}{super()._path}"
 
 
 class GCSPath(CloudPath):

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -73,6 +73,8 @@ class CloudPath(upath.core.UPath):
 
     @property
     def path(self) -> str:
+        if self._url is None:
+            raise RuntimeError(str(self))
         return f"{self._url.netloc}{super()._path}"
 
 

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlunsplit
+
 from fsspec.asyn import sync
 
 import upath.core
@@ -43,7 +45,7 @@ class HTTPPath(upath.core.UPath):
         relative path to `self`.
         """
         complete_address = self._format_parsed_parts(
-            None, None, [self.path], url=self._url, **self._kwargs
+            None, None, [self._path], url=self._url, **self._kwargs
         )
 
         if name.startswith(complete_address):
@@ -83,3 +85,8 @@ class HTTPPath(upath.core.UPath):
                     break
 
         return resolved_path
+
+    @property
+    def path(self) -> str:
+        # http filesystems use the full url as path
+        return urlunsplit(self._url)

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -89,4 +89,6 @@ class HTTPPath(upath.core.UPath):
     @property
     def path(self) -> str:
         # http filesystems use the full url as path
+        if self._url is None:
+            raise RuntimeError(str(self))
         return urlunsplit(self._url)

--- a/upath/implementations/webdav.py
+++ b/upath/implementations/webdav.py
@@ -53,10 +53,14 @@ class WebdavPath(upath.core.UPath):
 
     @property
     def protocol(self) -> str:
+        if self._url is None:
+            raise RuntimeError(str(self))
         return self._url.scheme.split("+")[0]
 
     @property
     def storage_options(self) -> dict[str, Any]:
+        if self._url is None:
+            raise RuntimeError(str(self))
         sopts = super().storage_options
         http_protocol = self._url.scheme.split("+")[1]
         assert http_protocol in {"http", "https"}

--- a/upath/implementations/webdav.py
+++ b/upath/implementations/webdav.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from urllib.parse import ParseResult
 from urllib.parse import urlunsplit
 
@@ -49,3 +50,16 @@ class WebdavPath(upath.core.UPath):
         name = name.strip("/")
 
         return name
+
+    @property
+    def protocol(self) -> str:
+        return self._url.scheme.split("+")[0]
+
+    @property
+    def storage_options(self) -> dict[str, Any]:
+        sopts = super().storage_options
+        http_protocol = self._url.scheme.split("+")[1]
+        assert http_protocol in {"http", "https"}
+        base_url = urlunsplit(self._url._replace(scheme=http_protocol, path=""))
+        sopts["base_url"] = base_url
+        return sopts

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fsspec import filesystem
 
 from upath import UPath
 
@@ -416,3 +417,24 @@ class BaseTests:
         uri = p0.as_uri()
         p1 = UPath(uri, **p0.fs.storage_options)
         assert p0 == p1
+
+    def test_protocol(self):
+        protocol = self.path.protocol
+        protocols = [p] if isinstance((p := type(self.path.fs).protocol), str) else p
+        print(protocol, protocols)
+        assert protocol in protocols
+
+    def test_storage_options(self):
+        storage_options = self.path.storage_options
+        assert storage_options == self.path.fs.storage_options
+
+    def test_read_with_fsspec(self):
+        p = self.path.joinpath("file2.txt")
+
+        protocol = p.protocol
+        storage_options = p.storage_options
+        path = p.path
+
+        fs = filesystem(protocol, **storage_options)
+        with fs.open(path) as f:
+            assert f.read() == b"hello world"

--- a/upath/tests/implementations/test_azure.py
+++ b/upath/tests/implementations/test_azure.py
@@ -44,3 +44,8 @@ class TestAzurePath(BaseTests):
 
     def test_rglob(self, pathlib_base):
         return super().test_rglob(pathlib_base)
+
+    def test_protocol(self):
+        # test all valid protocols for azure...
+        protocol = self.path.protocol
+        assert protocol in ["abfs", "abfss", "adl", "az"]

--- a/upath/tests/implementations/test_webdav.py
+++ b/upath/tests/implementations/test_webdav.py
@@ -12,3 +12,11 @@ class TestUPathWebdav(BaseTests):
 
     def test_fsspec_compat(self):
         pass
+
+    def test_storage_options(self):
+        # we need to add base_url to storage options for webdav filesystems,
+        # to be able to serialize the http protocol to string...
+        storage_options = self.path.storage_options
+        base_url = storage_options.pop("base_url")
+        assert storage_options == self.path.fs.storage_options
+        assert base_url == self.path.fs.client.base_url


### PR DESCRIPTION
This PR adds `.storage_options` and `.protocol` to `UPath`.

The "non-pathlib" interface of `UPath` is then:

- `UPath.protocol: str` the fsspec protocol
- `UPath.storage_options: dict[str, Any]` the storage_options for the fsspec class
- `UPath.path: str` the fsspec compatible path for use with the fsspec class
- `UPath.fs: AbstractFileSystem` convenience attribute to access a instantiated fsspec class

the first three provide a public interface to access a file via fsspec as follows:

```python
pth = UPath(..., **sopts)

from fsspec import filesystem

fs = filesystem(pth.protocol, **pth.storage_options)
with fs.open(pth.path) as f:
    data = f.read()
```

This closes #129, and closes #91.


**additional changes:**

- To support correct behavior for cloud filesystems `.path` had to be overwritten to return a path that includes the bucket (consistent with fsspec).
- Since the webdav filesystem doesn't serialize to string well (which is why we use the `webdav+http` and `webdav+https` protocol workaround) the WebdavPath.protocol returns `"webdav"` and the `base_url` is added to the `.storage_options`. Which then allows to support the usecase from the code mentioned above again.
- `HTTPPath().path` returns a full url, in line with fsspec behavior. 

**extra note regarding local filesystems**

```python
# protocol is empty string for non-uri localpaths:
p = UPath("/path/file.txt")
assert isinstance(p, PosixUPath)
assert p.protocol == ""

# and it's "file" for uri localpaths
u = UPath("file:///path/file.txt")
assert isinstance(p, LocalPath)
assert p.protocol == "file"
```

Both `"file"` and `""` return `LocalFileSystem` when using `fsspec.get_filesystem_class(protocol)`.