### PR TITLE
upath.registry: don't rely on fsspec.registry.available_protocols

### DIFF
--- a/upath/registry.py
+++ b/upath/registry.py
@@ -41,7 +41,7 @@ from typing import Iterator
 from typing import MutableMapping
 
 from fsspec.core import get_filesystem_class
-from fsspec.registry import available_protocols
+from fsspec.registry import known_implementations as _fsspec_known_implementations
 
 import upath.core
 
@@ -138,7 +138,7 @@ def available_implementations(*, fallback: bool = False) -> list[str]:
     if not fallback:
         return impl
     else:
-        return list({*impl, *available_protocols()})
+        return list({*impl, *list(_fsspec_known_implementations)})
 
 
 def register_implementation(

--- a/upath/tests/test_registry.py
+++ b/upath/tests/test_registry.py
@@ -1,5 +1,5 @@
 import pytest
-from fsspec.registry import available_protocols
+from fsspec.registry import known_implementations
 
 from upath import UPath
 from upath.registry import available_implementations
@@ -64,7 +64,7 @@ def test_available_implementations():
 
 def test_available_implementations_with_fallback():
     impl = available_implementations(fallback=True)
-    assert set(impl) == IMPLEMENTATIONS.union(available_protocols())
+    assert set(impl) == IMPLEMENTATIONS.union(list(known_implementations))
 
 
 def test_available_implementations_with_entrypoint(fake_entrypoint):


### PR DESCRIPTION
We should take better care of our minimum version boundaries. (should be easy too... We have one dependency 😅 )

For now, restore compatibility with `fsspec<2022.03.0`.

A few things to note though, when running with an older fsspec:
- gcsfs mkdir tests fail with gcsfs<2022.03.0
- webdav protocol is not known in fsspec<2022.05.0


Addresses #138 