### PR TITLE
require fsspec>=2022.1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,12 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ['3.8', '3.9', '3.10', '3.11']
+        fsspec: ['']
+
+        include:
+          - os: ubuntu-20.04
+            pyv: '3.8'
+            fsspec: 'minversion'
 
     steps:
     - name: Check out the repository
@@ -41,7 +47,7 @@ jobs:
         nox --version
 
     - name: Run tests
-      run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --cov-report=xml
+      run: nox -s tests-${{ matrix.fsspec || matrix.pyv }} -- --cov-report=xml
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ universal_pathlib.implementations =
     myproto = my_module.submodule:MyPath
 ```
 
+### Known issues solvable by installing newer upstream dependencies
+
+Some issues in UPath's behavior with specific filesystems can be fixed by installing newer versions of
+the dependencies. The following list will be kept up to date whenever we encounter more:
+
+- **UPath().glob()** fsspec fixed its glob behavior when handling `**` patterns in versions `fsspec>=2023.9.0`
+- **GCSPath().mkdir()** a few mkdir quirks are solved by installing `gcsfs>=2022.7.1`
+- **fsspec.filesystem(WebdavPath().protocol)** the webdav protocol was added to fsspec in version `fsspec>=2022.5.0`
+
 ## Contributing
 
 Contributions are very welcome.

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,20 @@ def tests(session: nox.Session) -> None:
     )
 
 
+@nox.session(python="3.8", name="tests-minversion")
+def tests_minversion(session: nox.Session) -> None:
+    session.install("fsspec==2022.1.0", ".[dev]")
+    session.run(
+        "pytest",
+        "-m",
+        "not hdfs",
+        "--cov",
+        "--cov-config=pyproject.toml",
+        *session.posargs,
+        env={"COVERAGE_FILE": f".coverage.{session.python}"},
+    )
+
+
 @nox.session
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.8
 zip_safe = False
 packages = find:
 install_requires=
-    fsspec
+    fsspec>=2022.1.0
 
 [options.extras_require]
 tests =

--- a/upath/tests/implementations/test_gcs.py
+++ b/upath/tests/implementations/test_gcs.py
@@ -5,6 +5,7 @@ from upath.implementations.cloud import GCSPath
 
 from ..cases import BaseTests
 from ..utils import skip_on_windows
+from ..utils import xfail_if_version
 
 
 @skip_on_windows
@@ -34,3 +35,15 @@ class TestGCSPath(BaseTests):
     @pytest.mark.skip
     def test_makedirs_exist_ok_false(self):
         pass
+
+    @xfail_if_version("gcsfs", lt="2022.7.1", reason="requires gcsfs>=2022.7.1")
+    def test_mkdir(self):
+        super().test_mkdir()
+
+    @xfail_if_version("gcsfs", lt="2022.7.1", reason="requires gcsfs>=2022.7.1")
+    def test_mkdir_exists_ok_false(self):
+        super().test_mkdir_exists_ok_false()
+
+    @xfail_if_version("gcsfs", lt="2022.7.1", reason="requires gcsfs>=2022.7.1")
+    def test_mkdir_exists_ok_true(self):
+        super().test_mkdir_exists_ok_true()

--- a/upath/tests/implementations/test_webdav.py
+++ b/upath/tests/implementations/test_webdav.py
@@ -3,6 +3,7 @@ import pytest  # noqa: F401
 from upath import UPath
 
 from ..cases import BaseTests
+from ..utils import xfail_if_version
 
 
 class TestUPathWebdav(BaseTests):
@@ -20,3 +21,7 @@ class TestUPathWebdav(BaseTests):
         base_url = storage_options.pop("base_url")
         assert storage_options == self.path.fs.storage_options
         assert base_url == self.path.fs.client.base_url
+
+    @xfail_if_version("fsspec", lt="2022.5.0", reason="requires fsspec>=2022.5.0")
+    def test_read_with_fsspec(self):
+        super().test_read_with_fsspec()


### PR DESCRIPTION
This PR closes #141 by introducing a minimum version requirement for `fsspec>=2022.1.0`. I went as far back as reasonable before larger parts of the test suite started failing.

Some notes:
- I'm xfailing the few tests that require slightly newer versions of fsspec for specific implementations. (I.e. some mkdir stuff for `gcsfs<2022.7.1`, or a webdav test that needs `fsspec>=2022.5.0`, etc...)

TODO:
- [x] add CI job testing against `fsspec==2022.1.0`
- [x] decide if we should:
  - fix the fs specific behavior for these xfailed tests :no_entry_sign: 
  - add min version requirements per implementation :no_entry_sign: 
  - just document them (my preferred option right now) :heavy_check_mark: 