### PR TITLE
Implementation of 'local://' URI Scheme Support

### DIFF
--- a/upath/registry.py
+++ b/upath/registry.py
@@ -64,6 +64,7 @@ class _Registry(MutableMapping[str, "type[upath.core.UPath]"]):
         "adl": "upath.implementations.cloud.AzurePath",
         "az": "upath.implementations.cloud.AzurePath",
         "file": "upath.implementations.local.LocalPath",
+        "local": "upath.implementations.local.LocalPath",
         "gcs": "upath.implementations.cloud.GCSPath",
         "gs": "upath.implementations.cloud.GCSPath",
         "hdfs": "upath.implementations.hdfs.HDFSPath",

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -1,5 +1,7 @@
 import pytest  # noqa: F401
+from fsspec import __version__ as fsspec_version
 from fsspec import get_filesystem_class
+from packaging.version import Version
 
 from upath import UPath
 from upath.implementations.http import HTTPPath
@@ -39,6 +41,27 @@ class TestUPathHttp(BaseTests):
     @pytest.mark.skip
     def test_mkdir(self):
         pass
+
+    @pytest.mark.parametrize(
+        "pattern",
+        (
+            "*.txt",
+            pytest.param(
+                "*",
+                marks=pytest.mark.xfail(reason="requires fsspec<=2023.10.0")
+                if Version(fsspec_version) > Version("2023.10.0")
+                else (),
+            ),
+            pytest.param(
+                "**/*.txt",
+                marks=pytest.mark.xfail(reason="requires fsspec>=2023.9.0")
+                if Version(fsspec_version) < Version("2023.9.0")
+                else (),
+            ),
+        ),
+    )
+    def test_glob(self, pathlib_base, pattern):
+        super().test_glob(pathlib_base, pattern)
 
     @pytest.mark.skip
     def test_mkdir_exists_ok_false(self):

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -6,6 +6,7 @@ from upath.implementations.http import HTTPPath
 
 from ..cases import BaseTests
 from ..utils import skip_on_windows
+from ..utils import xfail_if_no_ssl_connection
 
 try:
     get_filesystem_class("http")
@@ -19,6 +20,7 @@ def test_httppath():
     assert path.exists()
 
 
+@xfail_if_no_ssl_connection
 def test_httpspath():
     path = UPath("https://example.com")
     assert isinstance(path, HTTPPath)

--- a/upath/tests/implementations/test_local.py
+++ b/upath/tests/implementations/test_local.py
@@ -16,6 +16,7 @@ class TestFSSpecLocal(BaseTests):
     def test_is_LocalPath(self):
         assert isinstance(self.path, LocalPath)
 
+
 @skip_on_windows
 class TestRayIOFSSpecLocal(BaseTests):
     @pytest.fixture(autouse=True)

--- a/upath/tests/implementations/test_local.py
+++ b/upath/tests/implementations/test_local.py
@@ -4,6 +4,7 @@ from upath import UPath
 from upath.implementations.local import LocalPath
 from upath.tests.cases import BaseTests
 from upath.tests.utils import skip_on_windows
+from upath.tests.utils import xfail_if_version
 
 
 @skip_on_windows
@@ -18,6 +19,7 @@ class TestFSSpecLocal(BaseTests):
 
 
 @skip_on_windows
+@xfail_if_version("fsspec", lt="2023.10.0", reason="requires fsspec>=2023.10.0")
 class TestRayIOFSSpecLocal(BaseTests):
     @pytest.fixture(autouse=True)
     def path(self, local_testdir):

--- a/upath/tests/implementations/test_local.py
+++ b/upath/tests/implementations/test_local.py
@@ -15,3 +15,13 @@ class TestFSSpecLocal(BaseTests):
 
     def test_is_LocalPath(self):
         assert isinstance(self.path, LocalPath)
+
+@skip_on_windows
+class TestRayIOFSSpecLocal(BaseTests):
+    @pytest.fixture(autouse=True)
+    def path(self, local_testdir):
+        path = f"local://{local_testdir}"
+        self.path = UPath(path)
+
+    def test_is_LocalPath(self):
+        assert isinstance(self.path, LocalPath)

--- a/upath/tests/test_registry.py
+++ b/upath/tests/test_registry.py
@@ -17,6 +17,7 @@ IMPLEMENTATIONS = {
     "hdfs",
     "http",
     "https",
+    "local",
     "memory",
     "s3",
     "s3a",

--- a/upath/tests/utils.py
+++ b/upath/tests/utils.py
@@ -33,3 +33,14 @@ def xfail_if_version(module, *, reason, **conditions):
     for op, val in conditions.items():
         cond &= getattr(operator, op)(ver, Version(val))
     return pytest.mark.xfail(cond, reason=reason)
+
+
+def xfail_if_no_ssl_connection(func):
+    try:
+        import requests
+
+        requests.get("https://example.com")
+    except (ImportError, requests.exceptions.SSLError):
+        return pytest.mark.xfail(reason="No SSL connection")(func)
+    else:
+        return func


### PR DESCRIPTION
Added support for the local:// URI scheme. Although it's less ubiquitous than file://, this scheme is employed by key data engineering projects like Apache Spark and Ray.io for local file handling. 

Including this support broadens our software's versatility and adaptability with these projects.

[1] Spark Example -- https://spark.apache.org/docs/latest/submitting-applications.html#advanced-dependency-management:~:text=local%3A%20%2D%20a%20URI%20starting%20with%20local%3A/%20is%20expected%20to%20exist%20as%20a%20local%20file%20on%20each%20worker%20node.%20This%20means%20that%20no%20network%20IO%20will%20be%20incurred%2C%20and%20works%20well%20for%20large%20files/JARs%20that%20are%20pushed%20to%20each%20worker%2C%20or%20shared%20via%20NFS%2C%20GlusterFS%2C%20etc. 
[2] Ray.io example -- https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.write_json.html#:~:text=jsonl%22)%0A%3E%3E%3E-,ds.write_json(%22local%3A///tmp/data%22),-Time%20complexity%3A%20O 
[3] Genera Github Search for "local://" -- https://github.com/search?q=local://&type=code

Note this requires https://github.com/fsspec/filesystem_spec/pull/1381 to work.