### PR TITLE
Implement UPath.joinuri

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -20,6 +20,7 @@ from upath._compat import PathlibPathShim
 from upath._compat import str_remove_prefix
 from upath._compat import str_remove_suffix
 from upath._flavour import FSSpecFlavour
+from upath._flavour import upath_urijoin
 from upath._protocol import get_upath_protocol
 from upath._stat import UPathStatResult
 from upath.registry import get_upath_class
@@ -252,6 +253,18 @@ class UPath(PathlibPathShim, Path):
     @property
     def path(self) -> str:
         return super().__str__()
+
+    def joinuri(self, uri: str | os.PathLike[str]) -> UPath:
+        """Join with urljoin behavior for UPath instances"""
+        # short circuit if the new uri uses a different protocol
+        other_protocol = get_upath_protocol(uri)
+        if other_protocol and other_protocol != self._protocol:
+            return UPath(uri)
+        return UPath(
+            upath_urijoin(str(self), str(uri)),
+            protocol=other_protocol or self._protocol,
+            **self.storage_options,
+        )
 
     # === upath.UPath CUSTOMIZABLE API ================================
 

--- a/upath/core.py
+++ b/upath/core.py
@@ -603,6 +603,17 @@ class UPath(PathlibPathShim, Path):
             return False
         return super().is_relative_to(other, *_deprecated)
 
+    @property
+    def name(self):
+        tail = self._tail
+        if not tail:
+            return ""
+        name = tail[-1]
+        if not name and len(tail) >= 2:
+            return tail[-2]
+        else:
+            return name
+
     # === pathlib.Path ================================================
 
     def stat(self, *, follow_symlinks=True) -> UPathStatResult:

--- a/upath/tests/implementations/test_http.py
+++ b/upath/tests/implementations/test_http.py
@@ -143,3 +143,45 @@ def test_empty_parts(args, parts):
     pth = UPath(args)
     pth_parts = pth.parts
     assert pth_parts == parts
+
+
+def test_query_parameters_passthrough():
+    pth = UPath("http://example.com/?a=1&b=2")
+    assert pth.parts == ("http://example.com/", "?a=1&b=2")
+
+
+@pytest.mark.parametrize(
+    "base,rel,expected",
+    [
+        (
+            "http://www.example.com/a/b/index.html",
+            "image.png?version=1",
+            "http://www.example.com/a/b/image.png?version=1",
+        ),
+        (
+            "http://www.example.com/a/b/index.html",
+            "../image.png",
+            "http://www.example.com/a/image.png",
+        ),
+        (
+            "http://www.example.com/a/b/index.html",
+            "/image.png",
+            "http://www.example.com/image.png",
+        ),
+        (
+            "http://www.example.com/a/b/index.html",
+            "ftp://other.com/image.png",
+            "ftp://other.com/image.png",
+        ),
+        (
+            "http://www.example.com/a/b/index.html",
+            "//other.com/image.png",
+            "http://other.com/image.png",
+        ),
+    ],
+)
+def test_joinuri_behavior(base, rel, expected):
+    p0 = UPath(base)
+    pr = p0.joinuri(rel)
+    pe = UPath(expected)
+    assert pr == pe


### PR DESCRIPTION
Close #88 

This seems to be the best compromise regarding urljoin behavior for `UPath` classes.

`UPath.joinpath` behaves as close as possible to `pathlib.Path`

and

`UPath.joinuri` behaves as `urllib.parse.urljoin`