### PR TITLE
Fix open kwarg passthrough

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,6 +9,8 @@ ignore=
     # unindexed parameters in the str.format, see:
     # https://pypi.org/project/flake8-string-format/
     P1
+    # def statements on the same line with overload
+    E704
 max_line_length = 88
 max-complexity = 15
 select = B,C,E,F,W,T4,B902,T,P

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -120,7 +120,17 @@ class PosixUPath(PosixPath, LocalPath):
         newline=None,
         **fsspec_kwargs,
     ) -> IO[Any]:
-        return PosixPath.open(self, mode, buffering, encoding, errors, newline)
+        if fsspec_kwargs:
+            return super(LocalPath, self).open(
+                mode=mode,
+                buffering=buffering,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+                **fsspec_kwargs,
+            )
+        else:
+            return PosixPath.open(self, mode, buffering, encoding, errors, newline)
 
     if sys.version_info < (3, 12):
 
@@ -174,7 +184,17 @@ class WindowsUPath(WindowsPath, LocalPath):
         newline=None,
         **fsspec_kwargs,
     ) -> IO[Any]:
-        return WindowsPath.open(self, mode, buffering, encoding, errors, newline)
+        if fsspec_kwargs:
+            return super(LocalPath, self).open(
+                mode=mode,
+                buffering=buffering,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+                **fsspec_kwargs,
+            )
+        else:
+            return WindowsPath.open(self, mode, buffering, encoding, errors, newline)
 
     if sys.version_info < (3, 12):
 

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -6,6 +6,7 @@ from inspect import ismemberdescriptor
 from pathlib import Path
 from pathlib import PosixPath
 from pathlib import WindowsPath
+from typing import IO
 from typing import Any
 from typing import Collection
 from typing import MutableMapping
@@ -110,6 +111,17 @@ class PosixUPath(PosixPath, LocalPath):
     # assign all PosixPath methods/attrs to prevent multi inheritance issues
     _set_class_attributes(locals(), src=PosixPath)
 
+    def open(
+        self,
+        mode="r",
+        buffering=-1,
+        encoding=None,
+        errors=None,
+        newline=None,
+        **fsspec_kwargs,
+    ) -> IO[Any]:
+        return PosixPath.open(self, mode, buffering, encoding, errors, newline)
+
     if sys.version_info < (3, 12):
 
         def __new__(
@@ -152,6 +164,17 @@ class WindowsUPath(WindowsPath, LocalPath):
 
     # assign all WindowsPath methods/attrs to prevent multi inheritance issues
     _set_class_attributes(locals(), src=WindowsPath)
+
+    def open(
+        self,
+        mode="r",
+        buffering=-1,
+        encoding=None,
+        errors=None,
+        newline=None,
+        **fsspec_kwargs,
+    ) -> IO[Any]:
+        return WindowsPath.open(self, mode, buffering, encoding, errors, newline)
 
     if sys.version_info < (3, 12):
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -236,7 +236,25 @@ class BaseTests:
             new_dir._accessor.makedirs(new_dir, exist_ok=False)
 
     def test_open(self):
-        pass
+        p = self.path.joinpath("file1.txt")
+        with p.open(mode="r") as f:
+            assert f.read() == "hello world"
+        with p.open(mode="rb") as f:
+            assert f.read() == b"hello world"
+
+    def test_open_buffering(self):
+        p = self.path.joinpath("file1.txt")
+        p.open(buffering=-1)
+
+    def test_open_block_size(self):
+        p = self.path.joinpath("file1.txt")
+        with p.open(mode="r", block_size=8192) as f:
+            assert f.read() == "hello world"
+
+    def test_open_errors(self):
+        p = self.path.joinpath("file1.txt")
+        with p.open(mode="r", encoding="ascii", errors="strict") as f:
+            assert f.read() == "hello world"
 
     def test_owner(self):
         with pytest.raises(NotImplementedError):

--- a/upath/tests/implementations/test_data.py
+++ b/upath/tests/implementations/test_data.py
@@ -92,6 +92,26 @@ class TestUPathDataPath(BaseTests):
     def test_mkdir_parents_true_exists_ok_false(self):
         pass
 
+    def test_open(self):
+        p = UPath("data:text/plain;base64,aGVsbG8gd29ybGQ=")
+        with p.open(mode="r") as f:
+            assert f.read() == "hello world"
+        with p.open(mode="rb") as f:
+            assert f.read() == b"hello world"
+
+    def test_open_buffering(self):
+        self.path.open(buffering=-1)
+
+    def test_open_block_size(self):
+        p = UPath("data:text/plain;base64,aGVsbG8gd29ybGQ=")
+        with p.open(mode="r", block_size=8192) as f:
+            assert f.read() == "hello world"
+
+    def test_open_errors(self):
+        p = UPath("data:text/plain;base64,aGVsbG8gd29ybGQ=")
+        with p.open(mode="r", encoding="ascii", errors="strict") as f:
+            assert f.read() == "hello world"
+
     def test_read_bytes(self, pathlib_base):
         assert len(self.path.read_bytes()) == 69
 


### PR DESCRIPTION
Closes #171 

This allows `UPath.open()` to pass through kwargs to fsspec open.