### PR TITLE
Add typesafety checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,24 @@ jobs:
     - name: Run tests
       run: nox -s tests-${{ matrix.fsspec || matrix.pyv }} -- --cov-report=xml
 
+  typesafety:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.pyv }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Install nox
+        run: python -m pip install --upgrade nox
+
+      - name: Run typesafety checks
+        run: nox -s typesafety
+
   lint:
     runs-on: ubuntu-latest
 

--- a/dev/generate_flavours.py
+++ b/dev/generate_flavours.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any
+from typing import Literal
 from typing import cast
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
@@ -66,6 +67,22 @@ flavour_registry: dict[str, type[FileSystemFlavourBase]] = {}
 
 class FileSystemFlavourBase:
     """base class for the fsspec flavours"""
+
+    protocol: str | tuple[str, ...]
+    root_marker: Literal["/", ""]
+    sep: Literal["/"]
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        raise NotImplementedError
+
+    @staticmethod
+    def _get_kwargs_from_urls(path):
+        raise NotImplementedError
+
+    @classmethod
+    def _parent(cls, path):
+        raise NotImplementedError
 
     def __init_subclass__(cls: Any, **kwargs):
         if isinstance(cls.protocol, str):
@@ -99,12 +116,37 @@ FIX_METHODS = {
 }
 
 
+def _fix_abstract_file_system(x: str) -> str:
+    x = re.sub(
+        "protocol = 'abstract'",
+        "protocol: str | tuple[str, ...] = 'abstract'",
+        x
+    )
+    x = re.sub(
+        "root_marker = ''",
+        "root_marker: Literal['', '/'] = ''",
+        x
+    )
+    x = re.sub(
+        "sep = '/'",
+        "sep: Literal['/'] = '/'",
+        x
+    )
+    return x
+
+
 def _fix_azure_blob_file_system(x: str) -> str:
-    return re.sub(
-        r"host = ops.get\(\"host\", None\)",
-        'host: str | None = ops.get("host", None)',
+    x = re.sub(
+        r"if isinstance\(path, list\):",
+        'if isinstance(path, list):  # type: ignore[unreachable]',
         x,
     )
+    x = re.sub(
+        r"(return \[.*\])",
+        r"\1  # type: ignore[unreachable]",
+        x,
+    )
+    return x
 
 
 def _fix_memfs_file_system(x: str) -> str:
@@ -113,6 +155,15 @@ def _fix_memfs_file_system(x: str) -> str:
         "MemoryFileSystemFlavour",
         x,
     )
+
+
+def _fix_oss_file_system(x: str) -> str:
+    x = re.sub(
+        r"path_string: str = stringify_path\(path\)",
+        "path_string = stringify_path(path)",
+        x,
+    )
+    return x
 
 
 def _fix_xrootd_file_system(x: str) -> str:
@@ -129,8 +180,10 @@ def _fix_xrootd_file_system(x: str) -> str:
 
 
 FIX_SOURCE = {
+    "AbstractFileSystem": _fix_abstract_file_system,
     "AzureBlobFileSystem": _fix_azure_blob_file_system,
     "MemFS": _fix_memfs_file_system,
+    "OSSFileSystem": _fix_oss_file_system,
     "XRootDFileSystem": _fix_xrootd_file_system,
 }
 
@@ -303,7 +356,7 @@ def create_source() -> str:
             AbstractFileSystem,
             ["_strip_protocol", "_get_kwargs_from_urls", "_parent"],
             {},
-            ["protocol", "root_marker"],
+            ["protocol", "root_marker", "sep"],
             cls_suffix=BASE_CLASS_NAME_SUFFIX,
             base_cls="FileSystemFlavourBase",
         )

--- a/dev/generate_flavours.py
+++ b/dev/generate_flavours.py
@@ -118,27 +118,17 @@ FIX_METHODS = {
 
 def _fix_abstract_file_system(x: str) -> str:
     x = re.sub(
-        "protocol = 'abstract'",
-        "protocol: str | tuple[str, ...] = 'abstract'",
-        x
+        "protocol = 'abstract'", "protocol: str | tuple[str, ...] = 'abstract'", x
     )
-    x = re.sub(
-        "root_marker = ''",
-        "root_marker: Literal['', '/'] = ''",
-        x
-    )
-    x = re.sub(
-        "sep = '/'",
-        "sep: Literal['/'] = '/'",
-        x
-    )
+    x = re.sub("root_marker = ''", "root_marker: Literal['', '/'] = ''", x)
+    x = re.sub("sep = '/'", "sep: Literal['/'] = '/'", x)
     return x
 
 
 def _fix_azure_blob_file_system(x: str) -> str:
     x = re.sub(
         r"if isinstance\(path, list\):",
-        'if isinstance(path, list):  # type: ignore[unreachable]',
+        "if isinstance(path, list):  # type: ignore[unreachable]",
         x,
     )
     x = re.sub(

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,18 @@
+fsspec[git,hdfs,dask,http,sftp,smb]==2024.2.0
+
+# these dependencies define their own filesystems
+adlfs==2024.2.0
+boxfs==0.2.1
+dropboxdrivefs==1.3.1
+gcsfs==2024.2.0
+s3fs==2024.2.0
+ocifs==1.3.1
+webdav4[fsspec]==0.9.8
+# gfrivefs @ git+https://github.com/fsspec/gdrivefs@master broken ...
+morefs[asynclocalfs]==0.2.0
+dvc==3.47.0
+huggingface_hub==0.20.3
+lakefs-spec==0.7.0
+ossfs==2023.12.0
+fsspec-xrootd==0.2.4
+wandbfs==0.0.2

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,6 +97,7 @@ def typesafety(session):
     session.run(
         "python",
         "-m", "pytest",
+        "-v",
         "-p", "pytest-mypy-plugins",
         "--mypy-pyproject-toml-file", "pyproject.toml",
         "typesafety",

--- a/noxfile.py
+++ b/noxfile.py
@@ -96,10 +96,13 @@ def typesafety(session):
     session.install("-e", ".[tests]")
     session.run(
         "python",
-        "-m", "pytest",
+        "-m",
+        "pytest",
         "-v",
-        "-p", "pytest-mypy-plugins",
-        "--mypy-pyproject-toml-file", "pyproject.toml",
+        "-p",
+        "pytest-mypy-plugins",
+        "--mypy-pyproject-toml-file",
+        "pyproject.toml",
         "typesafety",
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -91,6 +91,18 @@ def type_checking(session):
     session.run("python", "-m", "mypy")
 
 
+@nox.session
+def typesafety(session):
+    session.install("-e", ".[tests]")
+    session.run(
+        "python",
+        "-m", "pytest",
+        "-p", "pytest-mypy-plugins",
+        "--mypy-pyproject-toml-file", "pyproject.toml",
+        "typesafety",
+    )
+
+
 @nox.session()
 def smoke(session):
     print("please tun `nox -s tests` instead")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ force_single_line = true
 line_length = 88
 
 [tool.pytest.ini_options]
-addopts = "-ra -m 'not hdfs'"
+addopts = "-ra -m 'not hdfs' -p no:pytest-mypy-plugins"
 markers = [
   "hdfs: mark test as hdfs",
   "pathlib: mark cpython pathlib tests",
@@ -61,7 +61,7 @@ exclude_lines = [
 
 [tool.mypy]
 # Error output
-show_column_numbers = true
+show_column_numbers = false
 show_error_codes = true
 show_error_context = true
 show_traceback = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.8
 zip_safe = False
 packages = find:
 install_requires=
-    fsspec>=2022.1.0
+    fsspec >=2022.1.0,!=2024.3.1
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ tests =
     pytest-cov==4.1.0
     pytest-mock==3.12.0
     pylint==2.17.4
-    mypy==1.9.0
+    mypy==1.10.0
     pytest-mypy-plugins==3.1.2
     packaging
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ tests =
     pytest-cov==4.1.0
     pytest-mock==3.12.0
     pylint==2.17.4
-    mypy==1.8.0
+    mypy==1.9.0
+    pytest-mypy-plugins==3.1.2
     packaging
 dev =
     %(tests)s

--- a/typesafety/test_upath_interface.yml
+++ b/typesafety/test_upath_interface.yml
@@ -54,7 +54,7 @@
     from upath import UPath
 
     p = UPath("abc")
-    reveal_type(p._url)  # N: Revealed type is "tuple[builtins.str, builtins.str, builtins.str, builtins.str, builtins.str, fallback=urllib.parse.SplitResult]"
+    reveal_type(p._url)  # NR: Revealed type is "[Tt]uple\[builtins.str, builtins.str, builtins.str, builtins.str, builtins.str, fallback=urllib.parse.SplitResult\]"
 
 # === upath pathlib.PurePath interface ================================
 

--- a/typesafety/test_upath_interface.yml
+++ b/typesafety/test_upath_interface.yml
@@ -1,6 +1,38 @@
-- case: upath_interface
+- case: upath_new
   disable_cache: true
   main: |
     from upath import UPath
 
     reveal_type(UPath("abc"))  # N: Revealed type is "upath.core.UPath"
+- case: upath_joinpath
+  disable_cache: true
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").joinpath("efg"))  # N: Revealed type is "upath.core.UPath"
+- case: upath_truediv
+  disable_cache: true
+  main: |
+    from upath import UPath
+
+    a = UPath("abc") / "efg"
+    reveal_type(a)  # N: Revealed type is "upath.core.UPath"
+- case: upath_rtruediv
+  disable_cache: true
+  main: |
+    from upath import UPath
+
+    a = "efg" / UPath("abc")
+    reveal_type(a)  # N: Revealed type is "upath.core.UPath"
+- case: upath_as_uri
+  disable_cache: true
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").as_uri())  # N: Revealed type is "builtins.str"
+- case: upath_as_posix
+  disable_cache: true
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").as_posix())  # N: Revealed type is "builtins.str"

--- a/typesafety/test_upath_interface.yml
+++ b/typesafety/test_upath_interface.yml
@@ -534,5 +534,34 @@
 
     reveal_type(UPath("abc").write_text("efg"))  # N: Revealed type is "builtins.int"
 
-# link_to
-# walk
+- case: upath_link_to_py38
+  disable_cache: false
+  mypy_config: python_version = 3.8
+  main: |
+    from upath import UPath
+
+    UPath("abc").link_to
+
+- case: upath_link_to_py312plus
+  disable_cache: false
+  mypy_config: python_version = 3.12
+  main: |
+    from upath import UPath
+
+    UPath("abc").link_to  # E: "UPath" has no attribute "link_to"  [attr-defined]
+
+- case: upath_walk_py38
+  disable_cache: false
+  mypy_config: python_version = 3.8
+  main: |
+    from upath import UPath
+
+    UPath("abc").walk  # E: "UPath" has no attribute "walk"  [attr-defined]
+
+- case: upath_walk_py312plus
+  disable_cache: false
+  mypy_config: python_version = 3.12
+  main: |
+      from upath import UPath
+
+      reveal_type(UPath("abc").walk())  # N: Revealed type is "typing.Iterator[tuple[upath.core.UPath, builtins.list[builtins.str], builtins.list[builtins.str]]]"

--- a/typesafety/test_upath_interface.yml
+++ b/typesafety/test_upath_interface.yml
@@ -1,38 +1,538 @@
-- case: upath_new
-  disable_cache: true
+- case: upath_constructor
+  disable_cache: false
   main: |
     from upath import UPath
 
     reveal_type(UPath("abc"))  # N: Revealed type is "upath.core.UPath"
-- case: upath_joinpath
-  disable_cache: true
+
+# === special upath attributes and methods ============================
+
+- case: upath_special_protocol
+  disable_cache: false
   main: |
     from upath import UPath
 
-    reveal_type(UPath("abc").joinpath("efg"))  # N: Revealed type is "upath.core.UPath"
+    p = UPath("abc")
+    reveal_type(p.protocol)  # N: Revealed type is "builtins.str"
+
+- case: upath_special_storage_options
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.storage_options)  # N: Revealed type is "typing.Mapping[builtins.str, Any]"
+
+- case: upath_special_path
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.path)  # N: Revealed type is "builtins.str"
+
+- case: upath_special_fs
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    # todo: this can change once fsspec is typed
+    reveal_type(p.fs)  # N: Revealed type is "Any"
+
+- case: upath_special_joinuri
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.joinuri("efg"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_special__url
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p._url)  # N: Revealed type is "tuple[builtins.str, builtins.str, builtins.str, builtins.str, builtins.str, fallback=urllib.parse.SplitResult]"
+
+# === upath pathlib.PurePath interface ================================
+
+- case: upath_parts
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.parts)  # N: Revealed type is "builtins.tuple[builtins.str, ...]"
+
+- case: upath_drive
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.drive)  # N: Revealed type is "builtins.str"
+
+- case: upath_root
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.root)  # N: Revealed type is "builtins.str"
+
+- case: upath_anchor
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.anchor)  # N: Revealed type is "builtins.str"
+
+- case: upath_name
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.name)  # N: Revealed type is "builtins.str"
+
+- case: upath_suffix
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.suffix)  # N: Revealed type is "builtins.str"
+
+- case: upath_suffixes
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.suffixes)  # N: Revealed type is "builtins.list[builtins.str]"
+
+- case: upath_stem
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.stem)  # N: Revealed type is "builtins.str"
+
+- case: upath_hashable
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(hash(p))  # N: Revealed type is "builtins.int"
+
+# __fspath__
+
+- case: upath_sortable
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    a = UPath("abc")
+    b = UPath("efg")
+    reveal_type(a < b)  # N: Revealed type is "builtins.bool"
+
 - case: upath_truediv
-  disable_cache: true
+  disable_cache: false
   main: |
     from upath import UPath
 
     a = UPath("abc") / "efg"
     reveal_type(a)  # N: Revealed type is "upath.core.UPath"
+
 - case: upath_rtruediv
-  disable_cache: true
+  disable_cache: false
   main: |
     from upath import UPath
 
     a = "efg" / UPath("abc")
     reveal_type(a)  # N: Revealed type is "upath.core.UPath"
-- case: upath_as_uri
-  disable_cache: true
-  main: |
-    from upath import UPath
 
-    reveal_type(UPath("a").as_uri())  # N: Revealed type is "builtins.str"
+# __bytes__
+
 - case: upath_as_posix
-  disable_cache: true
+  disable_cache: false
   main: |
     from upath import UPath
 
     reveal_type(UPath("a").as_posix())  # N: Revealed type is "builtins.str"
+
+- case: upath_as_uri
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").as_uri())  # N: Revealed type is "builtins.str"
+
+- case: upath_is_absolute
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").is_absolute())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_reserved
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").is_reserved())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_relative_to
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").is_relative_to("b"))  # N: Revealed type is "builtins.bool"
+
+- case: upath_match
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").match("b"))  # N: Revealed type is "builtins.bool"
+
+- case: upath_relative_to
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").relative_to("b"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_with_name
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").with_name("b"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_with_stem
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").with_stem("b"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_with_suffix
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("a").with_suffix("b"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_joinpath
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").joinpath("efg"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_parents
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.parents)  # N: Revealed type is "typing.Sequence[upath.core.UPath]"
+
+- case: upath_parent
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    p = UPath("abc")
+    reveal_type(p.parent)  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_with_segments
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").with_segments("efg"))  # N: Revealed type is "upath.core.UPath"
+
+# === upath pathlib.Path methods ======================================
+
+- case: upath_cwd
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath.cwd())  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_stat
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").stat())  # N: Revealed type is "upath._stat.UPathStatResult"
+
+- case: upath_chmod
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").chmod(0o777))  # N: Revealed type is "None"
+
+- case: upath_exists
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").exists())  # N: Revealed type is "builtins.bool"
+
+- case: upath_glob
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").glob("efg"))  # N: Revealed type is "typing.Generator[upath.core.UPath, None, None]"
+
+- case: upath_rglob
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").rglob("efg"))  # N: Revealed type is "typing.Generator[upath.core.UPath, None, None]"
+
+- case: upath_is_dir
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_dir())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_file
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_file())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_symlink
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_symlink())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_socket
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_socket())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_fifo
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_fifo())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_block_device
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_block_device())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_char_device
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_char_device())  # N: Revealed type is "builtins.bool"
+
+- case: upath_is_junction
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_junction())  # N: Revealed type is "builtins.bool"
+
+- case: upath_iterdir
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").iterdir())  # N: Revealed type is "typing.Generator[upath.core.UPath, None, None]"
+
+- case: upath_lchmod
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").lchmod(0o777))  # N: Revealed type is "None"
+
+- case: upath_lstat
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").lstat())  # N: Revealed type is "upath._stat.UPathStatResult"
+
+- case: upath_mkdir
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").mkdir())  # N: Revealed type is "None"
+
+- case: upath_open_default
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").open())  # N: Revealed type is "typing.TextIO"
+
+- case: upath_open_text
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").open("r"))  # N: Revealed type is "typing.TextIO"
+
+- case: upath_open_binary
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").open("rb"))  # N: Revealed type is "typing.BinaryIO"
+
+- case: upath_is_mount
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").is_mount())  # N: Revealed type is "builtins.bool"
+
+- case: upath_readlink
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").readlink())  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_rename
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").rename("efg"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_replace
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").replace("efg"))  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_resolve
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").resolve())  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_rmdir
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").rmdir())  # N: Revealed type is "None"
+
+- case: upath_symlink_to
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").symlink_to("efg"))  # N: Revealed type is "None"
+
+- case: upath_hardlink_to
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").hardlink_to("efg"))  # N: Revealed type is "None"
+
+- case: upath_touch
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").touch())  # N: Revealed type is "None"
+
+- case: upath_unlink
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").unlink())  # N: Revealed type is "None"
+
+- case: upath_home
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath.home())  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_absolute
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").absolute())  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_expanduser
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").expanduser())  # N: Revealed type is "upath.core.UPath"
+
+- case: upath_read_bytes
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").read_bytes())  # N: Revealed type is "builtins.bytes"
+
+- case: upath_read_text
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").read_text())  # N: Revealed type is "builtins.str"
+
+- case: upath_samefile
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").samefile("efg"))  # N: Revealed type is "builtins.bool"
+
+- case: upath_write_bytes
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").write_bytes(b"efg"))  # N: Revealed type is "builtins.int"
+
+- case: upath_write_text
+  disable_cache: false
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc").write_text("efg"))  # N: Revealed type is "builtins.int"
+
+# link_to
+# walk

--- a/typesafety/test_upath_interface.yml
+++ b/typesafety/test_upath_interface.yml
@@ -1,0 +1,6 @@
+- case: upath_interface
+  disable_cache: true
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("abc"))  # N: Revealed type is "upath.core.UPath"

--- a/upath/_compat.py
+++ b/upath/_compat.py
@@ -304,21 +304,6 @@ else:
             else:
                 return tuple(self._tail)
 
-        def joinpath(self, *pathsegments):
-            return self.with_segments(self, *pathsegments)
-
-        def __truediv__(self, key):
-            try:
-                return self.joinpath(key)
-            except TypeError:
-                return NotImplemented
-
-        def __rtruediv__(self, key):
-            try:
-                return self.with_segments(key, self)
-            except TypeError:
-                return NotImplemented
-
         @property
         def parent(self):
             drv = self.drive

--- a/upath/_compat.py
+++ b/upath/_compat.py
@@ -490,7 +490,8 @@ class FSSpecAccessorShim:
         )
 
 
-F = TypeVar("F")
+RT = TypeVar("RT")
+F = Callable[..., RT]
 
 
 def deprecated(*, python_version: tuple[int, ...]) -> Callable[[F], F]:

--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -228,7 +228,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
             out = pth.__fspath__()
         elif isinstance(pth, os.PathLike):
             out = str(pth)
-        elif hasattr(pth, "path"):
+        elif hasattr(pth, "path"):  # type: ignore[unreachable]
             out = pth.path
         else:
             out = str(pth)

--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -278,9 +278,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
             pN = list(map(self.stringify_path, paths))
             drv = ""
         if self.supports_empty_parts:
-            return drv + self.sep.join(
-                [str_remove_suffix(p0, self.sep), *pN]
-            )
+            return drv + self.sep.join([str_remove_suffix(p0, self.sep), *pN])
         else:
             return drv + posixpath.join(p0, *pN)
 

--- a/upath/_flavour_sources.py
+++ b/upath/_flavour_sources.py
@@ -72,6 +72,7 @@ class FileSystemFlavourBase:
         raise NotImplementedError
 
     def __init_subclass__(cls: Any, **kwargs):
+        protocols: tuple[str, ...]
         if isinstance(cls.protocol, str):
             protocols = (cls.protocol,)
         else:

--- a/upath/_flavour_sources.py
+++ b/upath/_flavour_sources.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any
+from typing import Literal
 from typing import cast
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
@@ -54,6 +55,22 @@ flavour_registry: dict[str, type[FileSystemFlavourBase]] = {}
 class FileSystemFlavourBase:
     """base class for the fsspec flavours"""
 
+    protocol: str | tuple[str, ...]
+    root_marker: Literal["/", ""]
+    sep: Literal["/"]
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        raise NotImplementedError
+
+    @staticmethod
+    def _get_kwargs_from_urls(path):
+        raise NotImplementedError
+
+    @classmethod
+    def _parent(cls, path):
+        raise NotImplementedError
+
     def __init_subclass__(cls: Any, **kwargs):
         if isinstance(cls.protocol, str):
             protocols = (cls.protocol,)
@@ -68,8 +85,9 @@ class FileSystemFlavourBase:
 class AbstractFileSystemFlavour(FileSystemFlavourBase):
     __orig_class__ = 'fsspec.spec.AbstractFileSystem'
     __orig_version__ = '2024.2.0'
-    protocol = 'abstract'
-    root_marker = ''
+    protocol: str | tuple[str, ...] = 'abstract'
+    root_marker: Literal['', '/'] = ''
+    sep: Literal['/'] = '/'
 
     @classmethod
     def _strip_protocol(cls, path):
@@ -164,8 +182,8 @@ class AzureBlobFileSystemFlavour(AbstractFileSystemFlavour):
         str
             Returns a path without the protocol
         """
-        if isinstance(path, list):
-            return [cls._strip_protocol(p) for p in path]
+        if isinstance(path, list):  # type: ignore[unreachable]
+            return [cls._strip_protocol(p) for p in path]  # type: ignore[unreachable]
 
         STORE_SUFFIX = ".dfs.core.windows.net"
         logger.debug(f"_strip_protocol for {path}")
@@ -197,7 +215,7 @@ class AzureBlobFileSystemFlavour(AbstractFileSystemFlavour):
         """Get the account_name from the urlpath and pass to storage_options"""
         ops = infer_storage_options(urlpath)
         out = {}
-        host: str | None = ops.get("host", None)
+        host = ops.get("host", None)
         if host:
             match = re.match(
                 r"(?P<account_name>.+)\.(dfs|blob)\.core\.windows\.net", host
@@ -675,7 +693,7 @@ class OSSFileSystemFlavour(AbstractFileSystemFlavour):
         """
         if isinstance(path, list):
             return [cls._strip_protocol(p) for p in path]
-        path_string: str = stringify_path(path)
+        path_string = stringify_path(path)
         if path_string.startswith("oss://"):
             path_string = path_string[5:]
 

--- a/upath/_stat.py
+++ b/upath/_stat.py
@@ -45,7 +45,7 @@ def _get_stat_result_extra_fields() -> tuple[str, ...]:
     sr = os.stat_result(range(os.stat_result.n_fields))
     rd = sr.__reduce__()
     assert isinstance(rd, tuple), "unexpected return os.stat_result.__reduce__"
-    _, (_, extra) = sr.__reduce__()
+    _, (_, extra) = rd
     extra_fields = sorted(extra, key=extra.__getitem__)
     return tuple(extra_fields)
 
@@ -317,7 +317,7 @@ class UPathStatResult:
         for field in self._fields:
             yield int(getattr(self, field))
 
-    def index(self, value: int, start: int = 0, stop: int = None, /) -> int:
+    def index(self, value: int, start: int = 0, stop: int | None = None, /) -> int:
         """the sequence interface index method."""
         if stop is None:
             stop = len(self._seq)

--- a/upath/core.py
+++ b/upath/core.py
@@ -714,7 +714,11 @@ class UPath(PathlibPathShim, Path):
 
     # === pathlib.Path ================================================
 
-    def stat(self, *, follow_symlinks=True) -> UPathStatResult:  # type: ignore[override]
+    def stat(  # type: ignore[override]
+        self,
+        *,
+        follow_symlinks=True,
+    ) -> UPathStatResult:
         if not follow_symlinks:
             warnings.warn(
                 "UPath.stat(follow_symlinks=False): follow_symlinks=False is"

--- a/upath/core.py
+++ b/upath/core.py
@@ -693,7 +693,7 @@ class UPath(PathlibPathShim, Path):
 
     # === pathlib.Path ================================================
 
-    def stat(self, *, follow_symlinks=True) -> UPathStatResult:
+    def stat(self, *, follow_symlinks=True) -> UPathStatResult:  # type: ignore[override]
         if not follow_symlinks:
             warnings.warn(
                 "UPath.stat(follow_symlinks=False): follow_symlinks=False is"
@@ -746,10 +746,10 @@ class UPath(PathlibPathShim, Path):
     def samefile(self, other_path):
         raise NotImplementedError
 
-    @overload
+    @overload  # type: ignore[override]
     def open(
         self,
-        mode: Literal["r", "w", "a"] = ...,
+        mode: Literal["r", "w", "a"] = "r",
         buffering: int = ...,
         encoding: str = ...,
         errors: str = ...,
@@ -760,13 +760,13 @@ class UPath(PathlibPathShim, Path):
     @overload
     def open(
         self,
-        mode: Literal["rb", "wb", "ab"] = ...,
+        mode: Literal["rb", "wb", "ab"],
         buffering: int = ...,
         encoding: str = ...,
         errors: str = ...,
         newline: str = ...,
         **fsspec_kwargs: Any,
-    ) -> BinaryIO: ...
+    ) -> BinaryIO: ...  # type: ignore[override]
 
     def open(
         self,

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -32,7 +32,7 @@ class HTTPPath(UPath):
         return args, protocol, storage_options
 
     @property
-    def root(self) -> str:
+    def root(self) -> str:  # type: ignore[override]
         return super().root or "/"
 
     def __str__(self):

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -28,7 +28,7 @@ class HTTPPath(UPath):
     ) -> tuple[tuple[str | os.PathLike, ...], str, dict[str, Any]]:
         # allow initialization via a path argument and protocol keyword
         if args and not str(args[0]).startswith(protocol):
-            args = (f"{protocol}://{args[0].lstrip('/')}", *args[1:])
+            args = (f"{protocol}://{str(args[0]).lstrip('/')}", *args[1:])
         return args, protocol, storage_options
 
     @property

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -101,7 +101,7 @@ def _upath_init(inst: PosixUPath | WindowsUPath) -> None:
     """helper to initialize the PosixPath/WindowsPath instance with UPath attrs"""
     inst._protocol = ""
     inst._storage_options = {}
-    if sys.version_info < (3, 10):
+    if sys.version_info < (3, 10) and hasattr(inst, "_init"):
         inst._init()
 
 

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -105,13 +105,13 @@ def _upath_init(inst: PosixUPath | WindowsUPath) -> None:
         inst._init()
 
 
-class PosixUPath(PosixPath, LocalPath):
+class PosixUPath(PosixPath, LocalPath):  # type: ignore[misc]
     __slots__ = ()
 
     # assign all PosixPath methods/attrs to prevent multi inheritance issues
     _set_class_attributes(locals(), src=PosixPath)
 
-    def open(
+    def open(  # type: ignore[override]
         self,
         mode="r",
         buffering=-1,
@@ -136,14 +136,14 @@ class PosixUPath(PosixPath, LocalPath):
 
         def __new__(
             cls, *args, protocol: str | None = None, **storage_options: Any
-        ) -> UPath:
+        ) -> PosixUPath:
             if os.name == "nt":
                 raise NotImplementedError(
                     f"cannot instantiate {cls.__name__} on your system"
                 )
             obj = super().__new__(cls, *args)
             obj._protocol = ""
-            return obj
+            return obj  # type: ignore[return-value]
 
         def __init__(
             self, *args, protocol: str | None = None, **storage_options: Any
@@ -169,13 +169,13 @@ class PosixUPath(PosixPath, LocalPath):
             return PosixPath.__str__(self)
 
 
-class WindowsUPath(WindowsPath, LocalPath):
+class WindowsUPath(WindowsPath, LocalPath):  # type: ignore[misc]
     __slots__ = ()
 
     # assign all WindowsPath methods/attrs to prevent multi inheritance issues
     _set_class_attributes(locals(), src=WindowsPath)
 
-    def open(
+    def open(  # type: ignore[override]
         self,
         mode="r",
         buffering=-1,
@@ -200,14 +200,14 @@ class WindowsUPath(WindowsPath, LocalPath):
 
         def __new__(
             cls, *args, protocol: str | None = None, **storage_options: Any
-        ) -> UPath:
+        ) -> WindowsUPath:
             if os.name != "nt":
                 raise NotImplementedError(
                     f"cannot instantiate {cls.__name__} on your system"
                 )
             obj = super().__new__(cls, *args)
             obj._protocol = ""
-            return obj
+            return obj  # type: ignore[return-value]
 
         def __init__(
             self, *args, protocol: str | None = None, **storage_options: Any

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -24,7 +24,7 @@ class DummyTestFS(LocalFileSystem):
     root_marker = "/"
 
     @classmethod
-    def _strip_protocol(cls, path, **_):
+    def _strip_protocol(cls, path):
         path = stringify_path(path)
         if path.startswith("mock://"):
             path = path[7:]

--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -24,7 +24,7 @@ class DummyTestFS(LocalFileSystem):
     root_marker = "/"
 
     @classmethod
-    def _strip_protocol(cls, path):
+    def _strip_protocol(cls, path, **_):
         path = stringify_path(path)
         if path.startswith("mock://"):
             path = path[7:]


### PR DESCRIPTION
Close #210 

This PR adds typesafety checks for the UPath class interface. Tests all public attributes / method return types.

currently missing (can be done in another PR):
- [ ] `__fspath__`
- [ ] `__bytes__`
- [ ] `_scandir`
- [x] `link_to` (on <3.12)
- [x] `walk` (on >=3.12)

Ideally, the type checks should also be done for subclasses (-> future PR).