### PR TITLE
Add `st_birthtime` as standard field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ cython_debug/
 
 # setuptools_scm
 upath/_version.py
+
+# vscode workspace settings
+.vscode/

--- a/upath/_stat.py
+++ b/upath/_stat.py
@@ -281,28 +281,32 @@ class UPathStatResult:
                 pass
         return self._seq[9]
 
+    @property
+    def st_birthtime(self) -> int | float:
+        """time of creation"""
+        for key in [
+            "birthtime",
+            "created",
+            "creation_time",
+            "timeCreated",
+            "created_at"
+        ]:
+            try:
+                raw_value = self._info[key]
+            except KeyError:
+                continue
+            try:
+                return _convert_value_to_timestamp(raw_value)
+            except (TypeError, ValueError):
+                pass
+        raise AttributeError("birthtime")
+
     # --- extra fields ------------------------------------------------
 
     def __getattr__(self, item):
         if item in self._fields_extra:
             return 0  # fallback default value
         raise AttributeError(item)
-
-    if "st_birthtime" in _fields_extra:
-
-        @property
-        def st_birthtime(self) -> int | float:
-            """time of creation"""
-            for key in ["created", "creation_time", "timeCreated", "created_at"]:
-                try:
-                    raw_value = self._info[key]
-                except KeyError:
-                    continue
-                try:
-                    return _convert_value_to_timestamp(raw_value)
-                except (TypeError, ValueError):
-                    pass
-            return 0
 
     # --- os.stat_result tuple interface ------------------------------
 

--- a/upath/_stat.py
+++ b/upath/_stat.py
@@ -289,7 +289,7 @@ class UPathStatResult:
             "created",
             "creation_time",
             "timeCreated",
-            "created_at"
+            "created_at",
         ]:
             try:
                 raw_value = self._info[key]

--- a/upath/tests/test_stat.py
+++ b/upath/tests/test_stat.py
@@ -25,15 +25,35 @@ def test_stat_as_info(pth_file):
 
 
 def test_stat_atime(pth_file):
-    assert isinstance(pth_file.stat().st_atime, (float, int))
+    atime = pth_file.stat().st_atime
+    assert isinstance(atime, (float, int))
+
+
+@pytest.mark.xfail(reason="fsspec does not return 'atime'")
+def test_stat_atime_value(pth_file):
+    atime = pth_file.stat().st_atime
+    assert atime > 0
 
 
 def test_stat_mtime(pth_file):
-    assert isinstance(pth_file.stat().st_mtime, (float, int))
+    mtime = pth_file.stat().st_mtime
+    assert isinstance(mtime, (float, int))
+
+
+def test_stat_mtime_value(pth_file):
+    mtime = pth_file.stat().st_mtime
+    assert mtime > 0
 
 
 def test_stat_ctime(pth_file):
-    assert isinstance(pth_file.stat().st_ctime, (float, int))
+    ctime = pth_file.stat().st_ctime
+    assert isinstance(ctime, (float, int))
+
+
+@pytest.mark.xfail(reason="fsspec returns 'created' but not 'ctime'")
+def test_stat_ctime_value(pth_file):
+    ctime = pth_file.stat().st_ctime
+    assert ctime > 0
 
 
 def test_stat_seq_interface(pth_file):

--- a/upath/tests/test_stat.py
+++ b/upath/tests/test_stat.py
@@ -56,6 +56,16 @@ def test_stat_ctime_value(pth_file):
     assert ctime > 0
 
 
+def test_stat_birthtime(pth_file):
+    birthtime = pth_file.stat().st_birthtime
+    assert isinstance(birthtime, (float, int))
+
+
+def test_stat_birthtime_value(pth_file):
+    birthtime = pth_file.stat().st_birthtime
+    assert birthtime > 0
+
+
 def test_stat_seq_interface(pth_file):
     assert len(tuple(pth_file.stat())) == os.stat_result.n_sequence_fields
     assert isinstance(pth_file.stat().index(0), int)


### PR DESCRIPTION
Adds support for st_birthtime regardless of OS environment. Adds tests that timestamp values return reasonable results.

Closes #253