### PR TITLE
upath: fix is_absolute on <3.12

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -945,6 +945,9 @@ class UPath(PathlibPathShim, Path):
     def absolute(self) -> Self:
         return self
 
+    def is_absolute(self) -> bool:
+        return self._flavour.isabs(str(self))
+
     def resolve(self, strict: bool = False) -> Self:
         _parts = self.parts
 

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -115,6 +115,9 @@ class BaseTests:
 
         assert not (self.path / "not-existing-file.txt").is_file()
 
+    def test_is_absolute(self):
+        assert self.path.is_absolute() is True
+
     def test_is_mount(self):
         assert self.path.is_mount() is False
 


### PR DESCRIPTION
Fixes `is_absolute` on python<3.12 as described here https://github.com/fsspec/universal_pathlib/issues/206#issuecomment-2143863666

Closes #206 