### PR TITLE
Fix touch exists_ok if file exists

### DIFF
--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -80,10 +80,3 @@ class S3Path(CloudPath):
 
 class AzurePath(CloudPath):
     __slots__ = ()
-
-    def touch(self, mode=0o666, exist_ok=True):
-        if exist_ok and self.exists():
-            with self.fs.open(self.path, mode="a"):
-                pass
-        else:
-            self.fs.touch(self.path, truncate=True)

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -320,6 +320,19 @@ class BaseTests:
     def test_symlink_to(self):
         pass
 
+    def test_touch_exists_ok_false(self):
+        f = self.path.joinpath("file1.txt")
+        assert f.exists()
+        with pytest.raises(FileExistsError):
+            f.touch(exist_ok=False)
+
+    def test_touch_exists_ok_true(self):
+        f = self.path.joinpath("file1.txt")
+        assert f.exists()
+        data = f.read_text()
+        f.touch(exist_ok=True)
+        assert f.read_text() == data
+
     def test_touch_unlink(self):
         path = self.path.joinpath("test_touch.txt")
         path.touch()

--- a/upath/tests/implementations/test_data.py
+++ b/upath/tests/implementations/test_data.py
@@ -133,9 +133,15 @@ class TestUPathDataPath(BaseTests):
         with pytest.raises(NotImplementedError):
             list(self.path.rglob("*"))
 
+    def test_touch_exists_ok_false(self):
+        with pytest.raises(FileExistsError):
+            self.path.touch(exist_ok=False)
+
+    def test_touch_exists_ok_true(self):
+        self.path.touch()
+
     def test_touch_unlink(self):
-        with pytest.raises(NotImplementedError):
-            self.path.touch()
+        self.path.touch()
         with pytest.raises(NotImplementedError):
             self.path.unlink()
 

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -53,20 +53,6 @@ class TestUPathS3(BaseTests):
             assert x.name != ""
             assert x.exists()
 
-    def test_touch_unlink(self):
-        path = self.path.joinpath("test_touch.txt")
-        path.touch()
-        assert path.exists()
-        path.unlink()
-        assert not path.exists()
-
-        # should raise FileNotFoundError since file is missing
-        with pytest.raises(FileNotFoundError):
-            path.unlink()
-
-        # file doesn't exists, but missing_ok is True
-        path.unlink(missing_ok=True)
-
     @pytest.mark.parametrize(
         "joiner", [["bucket", "path", "file"], ["bucket/path/file"]]
     )


### PR DESCRIPTION
Close #216 

This fixes behavior of touch. `truncate` should never be set on an existing file when using touch from the pathlib api.
This also silently ignores an error when the filesystem does not support touching an existing file. (We could consider throwing a warning in this case)