### PR TITLE
allow upath lstat

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -745,16 +745,15 @@ class UPath(PathlibPathShim, Path):
     ) -> UPathStatResult:
         if not follow_symlinks:
             warnings.warn(
-                "UPath.stat(follow_symlinks=False): follow_symlinks=False is"
-                " currently ignored.",
+                f"{type(self).__name__}.stat(follow_symlinks=False):"
+                " is currently ignored.",
                 UserWarning,
                 stacklevel=2,
             )
         return UPathStatResult.from_info(self.fs.stat(self.path))
 
     def lstat(self) -> UPathStatResult:  # type: ignore[override]
-        # return self.stat(follow_symlinks=False)
-        raise NotImplementedError
+        return self.stat(follow_symlinks=False)
 
     def exists(self, *, follow_symlinks=True) -> bool:
         return self.fs.exists(self.path)

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -61,8 +61,8 @@ class HTTPPath(UPath):
     def stat(self, follow_symlinks: bool = True):
         if not follow_symlinks:
             warnings.warn(
-                "HTTPPath.stat(follow_symlinks=False): follow_symlinks=False is"
-                " currently ignored.",
+                f"{type(self).__name__}.stat(follow_symlinks=False):"
+                " is currently ignored.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -181,8 +181,9 @@ class BaseTests:
             self.path.lchmod(mode=77)
 
     def test_lstat(self):
-        with pytest.raises(NotImplementedError):
-            self.path.lstat()
+        with pytest.warns(UserWarning, match="UPath.stat"):
+            st = self.path.lstat()
+            assert st is not None
 
     def test_mkdir(self):
         new_dir = self.path.joinpath("new_dir")

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -181,7 +181,7 @@ class BaseTests:
             self.path.lchmod(mode=77)
 
     def test_lstat(self):
-        with pytest.warns(UserWarning, match="UPath.stat"):
+        with pytest.warns(UserWarning, match=r"[A-Za-z]+.stat"):
             st = self.path.lstat()
             assert st is not None
 


### PR DESCRIPTION
raises a warning that not following symlinks is not supported.