### PR TITLE
Support python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        pyv: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         fsspec: ['']
 
         include:
@@ -41,6 +41,7 @@ jobs:
         PIP_DISABLE_PIP_VERSION_CHECK: ${{ matrix.pyv == '3.8' && matrix.os == 'macos-latest' }}
       with:
         python-version: ${{ matrix.pyv }}
+        allow-prereleases: true
 
     - name: Upgrade pip and nox
       run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ nox.options.sessions = "lint", "tests"
 locations = ("upath",)
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
 def tests(session: nox.Session) -> None:
     # workaround in case no aiohttp binary wheels are available
     session.env["AIOHTTP_NO_EXTENSIONS"] = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dev = [
     "requests",
     "gcsfs",
     "s3fs",
-    "moto[s3,server]",
+    # exclude moto installation on 3.13 windows until pywin32 wheels are available:
+    "moto[s3,server]; python_version<='3.12' or (python_version>'3.12' and os_name!='nt') ",
     "webdav4[fsspec]",
     "paramiko",
     "wsgidav",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Development Status :: 4 - Beta",
 ]
 keywords = ["filesystem-spec", "pathlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tests = [
     "packaging",
 ]
 dev = [
-    "adlfs",
+    "adlfs; python_version<='3.12' or (python_version>'3.12' and os_name!='nt') ",
     "aiohttp",
     "requests",
     "gcsfs",

--- a/upath/core.py
+++ b/upath/core.py
@@ -135,6 +135,9 @@ class UPath(PathlibPathShim, Path):
     _protocol_dispatch: bool | None = None
     _flavour = LazyFlavourDescriptor()
 
+    if sys.version_info >= (3, 13):
+        parser = _flavour
+
     # === upath.UPath constructor =====================================
 
     def __new__(

--- a/upath/core.py
+++ b/upath/core.py
@@ -871,7 +871,7 @@ class UPath(PathlibPathShim, Path):
                 continue
             # only want the path name with iterdir
             _, _, name = str_remove_suffix(name, "/").rpartition(self._flavour.sep)
-            yield self._make_child_relpath(name)
+            yield self.with_segments(*self.parts, name)
 
     def _scandir(self):
         raise NotImplementedError  # todo

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -532,6 +532,10 @@ class BaseTests:
         with fs.open(path) as f:
             assert f.read() == b"hello world"
 
+    @pytest.mark.xfail(
+        sys.version_info >= (3, 13),
+        reason="no support for private `._drv`, `._root`, `._parts` in 3.13",
+    )
     def test_access_to_private_api(self):
         # DO NOT access these private attributes in your code
         p = UPath(str(self.path), **self.path.storage_options)


### PR DESCRIPTION
Support Python 3.13 on the v0.2.x branch of `universal-pathlib`.

Closes #221, closes #245

The final 3.13 release is pretty close, so it's better to add support for downstream packages to be able to test.

**TODOs**:
- [ ] should probably add the stdlib tests for 3.13 too to be consistent.
- [x] update classifiers in pyproject.toml
- [x] figure out why boto3 wont install on windows 3.13

**MISSING SUPPORT UPSTREAM**
- Windows tests can't run because the python docker package [relies on pywin32](https://github.com/docker/docker-py/blob/a3652028b1ead708bd9191efb286f909ba6c2a49/pyproject.toml#L35) and there [are no wheels for 3.13 yet](https://pypi.org/project/pywin32/306/#files)