### PR TITLE
upath.implementations.cloud: move empty bucket checks to subclasses

### DIFF
--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -22,13 +22,6 @@ _CloudAccessor = _FSSpecAccessorShim
 class CloudPath(UPath):
     __slots__ = ()
 
-    def __init__(
-        self, *args, protocol: str | None = None, **storage_options: Any
-    ) -> None:
-        super().__init__(*args, protocol=protocol, **storage_options)
-        if not self.drive and len(self.parts) > 1:
-            raise ValueError("non key-like path provided (bucket/container missing)")
-
     @classmethod
     def _transform_init_args(
         cls,
@@ -71,6 +64,13 @@ class CloudPath(UPath):
 class GCSPath(CloudPath):
     __slots__ = ()
 
+    def __init__(
+        self, *args, protocol: str | None = None, **storage_options: Any
+    ) -> None:
+        super().__init__(*args, protocol=protocol, **storage_options)
+        if not self.drive and len(self.parts) > 1:
+            raise ValueError("non key-like path provided (bucket/container missing)")
+
     def mkdir(
         self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False
     ) -> None:
@@ -84,6 +84,20 @@ class GCSPath(CloudPath):
 class S3Path(CloudPath):
     __slots__ = ()
 
+    def __init__(
+        self, *args, protocol: str | None = None, **storage_options: Any
+    ) -> None:
+        super().__init__(*args, protocol=protocol, **storage_options)
+        if not self.drive and len(self.parts) > 1:
+            raise ValueError("non key-like path provided (bucket/container missing)")
+
 
 class AzurePath(CloudPath):
     __slots__ = ()
+
+    def __init__(
+        self, *args, protocol: str | None = None, **storage_options: Any
+    ) -> None:
+        super().__init__(*args, protocol=protocol, **storage_options)
+        if not self.drive and len(self.parts) > 1:
+            raise ValueError("non key-like path provided (bucket/container missing)")


### PR DESCRIPTION
Addresses #276 

airflows `ObjectStoragePath` derives from `CloudPath` but accepts `file://` URIs.
PR #264 introduced an early error for "cloudpaths" that were initialized with a URI without a netloc (bucket) which would later on cause problems.

moving this check to the subclasses for S3, GCS and Azure should fix airflows usage.