### PR TITLE
DEP: Ensure typing_extension is dependency for earlier python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ maintainers = [
 requires-python = ">=3.8"
 dependencies = [
     "fsspec >=2022.1.0,!=2024.3.1",
+    "typing_extensions; python_version<'3.11'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ maintainers = [
 requires-python = ">=3.8"
 dependencies = [
     "fsspec >=2022.1.0,!=2024.3.1",
-    "typing_extensions; python_version<'3.11'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -62,6 +61,7 @@ dev = [
     "pydantic",
     "pydantic-settings",
     "smbprotocol",
+    "typing_extensions; python_version<'3.11'",
 ]
 
 [project.urls]

--- a/upath/core.py
+++ b/upath/core.py
@@ -19,11 +19,6 @@ from typing import TypeVar
 from typing import overload
 from urllib.parse import urlsplit
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
 from fsspec.registry import get_filesystem_class
 from fsspec.spec import AbstractFileSystem
 
@@ -42,6 +37,11 @@ from upath.registry import get_upath_class
 
 if TYPE_CHECKING:
     from urllib.parse import SplitResult
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 __all__ = ["UPath"]
 

--- a/upath/implementations/sftp.py
+++ b/upath/implementations/sftp.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import sys
 from typing import Any
 from typing import Generator
+from typing import TYPE_CHECKING
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 from upath import UPath
 

--- a/upath/implementations/sftp.py
+++ b/upath/implementations/sftp.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Generator
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 11):

--- a/upath/implementations/smb.py
+++ b/upath/implementations/smb.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 import sys
 import warnings
-from typing import Any
 from typing import TYPE_CHECKING
+from typing import Any
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 11):

--- a/upath/implementations/smb.py
+++ b/upath/implementations/smb.py
@@ -4,11 +4,13 @@ import os
 import sys
 import warnings
 from typing import Any
+from typing import TYPE_CHECKING
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 import smbprotocol.exceptions
 


### PR DESCRIPTION
The following guard hits a `ModuleNotFoundError` on a fresh 3.10 environment

https://github.com/fsspec/universal_pathlib/blob/5486fa3c30cbb3f79637252d980994a1d738b0f5/upath/core.py#L22-L25

This PR adds `typing_extension` as an optional dependency for earlier Python versions.