### PR TITLE
Fix sftp join issue for non-root prefixed paths

### DIFF
--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -78,6 +78,7 @@ class ProtocolConfig(TypedDict):
     netloc_is_anchor: set[str]
     supports_empty_parts: set[str]
     meaningful_trailing_slash: set[str]
+    root_marker_override: dict[str, str]
 
 
 class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
@@ -109,8 +110,6 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
             "https",
             "s3",
             "s3a",
-            "sftp",
-            "ssh",
             "smb",
             "gs",
             "gcs",
@@ -135,6 +134,10 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
             "http",
             "https",
         },
+        "root_marker_override": {
+            "ssh": "/",
+            "sftp": "/",
+        },
     }
 
     def __init__(
@@ -144,6 +147,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
         netloc_is_anchor: bool = False,
         supports_empty_parts: bool = False,
         meaningful_trailing_slash: bool = False,
+        root_marker_override: str | None = None,
     ) -> None:
         """initialize the flavour with the given fsspec"""
         self._spec = spec
@@ -163,6 +167,12 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
         #   - UPath._parse_path
         self.has_meaningful_trailing_slash = bool(meaningful_trailing_slash)
 
+        # some filesystems require UPath to enforce a specific root marker
+        if root_marker_override is None:
+            self.root_marker_override = None
+        else:
+            self.root_marker_override = str(root_marker_override)
+
     @classmethod
     @lru_cache(maxsize=None)
     def from_protocol(
@@ -176,6 +186,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
             "netloc_is_anchor": protocol in _c["netloc_is_anchor"],
             "supports_empty_parts": protocol in _c["supports_empty_parts"],
             "meaningful_trailing_slash": protocol in _c["meaningful_trailing_slash"],
+            "root_marker_override": _c["root_marker_override"].get(protocol),
         }
 
         # first try to get an already imported fsspec filesystem class
@@ -217,7 +228,10 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
 
     @property
     def root_marker(self) -> str:
-        return self._spec.root_marker
+        if self.root_marker_override is not None:
+            return self.root_marker_override
+        else:
+            return self._spec.root_marker
 
     @property
     def local_file(self) -> bool:
@@ -278,7 +292,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
                 drv, p0 = self.splitdrive(path)
             p0 = p0 or self.sep
         else:
-            p0 = str(self.strip_protocol(path))
+            p0 = str(self.strip_protocol(path)) or self.root_marker
             pN = list(map(self.stringify_path, paths))
             drv = ""
         if self.supports_empty_parts:

--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -182,7 +182,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
         """return the fsspec flavour for the given protocol"""
 
         _c = cls.protocol_config
-        config = {
+        config: dict[str, Any] = {
             "netloc_is_anchor": protocol in _c["netloc_is_anchor"],
             "supports_empty_parts": protocol in _c["supports_empty_parts"],
             "meaningful_trailing_slash": protocol in _c["meaningful_trailing_slash"],

--- a/upath/tests/implementations/test_sftp.py
+++ b/upath/tests/implementations/test_sftp.py
@@ -46,6 +46,8 @@ class TestUPathSFTP(BaseTests):
         (("sftp://user@host",), ("/",)),
         (("sftp://user@host/",), ("/",)),
         (("sftp://user@host", ""), ("/",)),
+        (("sftp://user@host/", ""), ("/",)),
+        (("sftp://user@host", "/"), ("/",)),
         (("sftp://user@host/", "/"), ("/",)),
         (("sftp://user@host/abc",), ("/", "abc")),
         (("sftp://user@host", "abc"), ("/", "abc")),

--- a/upath/tests/implementations/test_sftp.py
+++ b/upath/tests/implementations/test_sftp.py
@@ -38,3 +38,22 @@ class TestUPathSFTP(BaseTests):
     @_xfail_old_fsspec
     def test_mkdir_parents_true_exists_ok_true(self):
         super().test_mkdir_parents_true_exists_ok_true()
+
+
+@pytest.mark.parametrize(
+    "args,parts",
+    [
+        (("sftp://user@host",), ("/",)),
+        (("sftp://user@host/",), ("/",)),
+        (("sftp://user@host", ""), ("/",)),
+        (("sftp://user@host/", "/"), ("/",)),
+        (("sftp://user@host/abc",), ("/", "abc")),
+        (("sftp://user@host", "abc"), ("/", "abc")),
+        (("sftp://user@host", "/abc"), ("/", "abc")),
+        (("sftp://user@host/", "/abc"), ("/", "abc")),
+    ],
+)
+def test_join_produces_correct_parts(args, parts):
+    pth = UPath(*args)
+    assert pth.storage_options == {"host": "host", "username": "user"}
+    assert pth.parts == parts


### PR DESCRIPTION
Fixes #289 

sftp/ssh UPath's now enforce absolute paths.