### PR TITLE
Fix: Add support for `abfss` protocol

### DIFF
--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -116,6 +116,7 @@ class WrappedFileSystemFlavour:  # (pathlib_abc.FlavourBase)
             "az",
             "adl",
             "abfs",
+            "abfss",
             "webdav+http",
             "webdav+https",
         },


### PR DESCRIPTION
### Description

This pull request addresses the issue where defining a `UPath` with the Azure protocol `"abfss"` causes a ValueError:
```python
File .../lib/python3.11/site-packages/upath/implementations/cloud.py:104, in AzurePath.__init__(self, protocol, *args, **storage_options)
    102 print(self.drive, len(self.parts))
    103 if not self.drive and len(self.parts) > 1:
--> 104     raise ValueError("non key-like path provided (bucket/container missing)")

ValueError: non key-like path provided (bucket/container missing)
```

This fixes #310 

### Fix

This pull request adds `"abfss"` to the  `WrappedFileSystemFlavour.protocol_config["netloc_is_anchor"]` list to ensure that the `splitdrive` method correctly handles paths with the `"abfss"` protocol.