### PR TITLE
tests: allow configuring smb port via env var

### DIFF
--- a/upath/tests/conftest.py
+++ b/upath/tests/conftest.py
@@ -426,7 +426,7 @@ def smb_container():
     container = "fsspec_smb"
     stop_docker(container)
     cfg = "-p -u 'testuser;testpass' -s 'home;/share;no;no;no;testuser'"
-    port = 445
+    port = int(os.environ.get("UPATH_TESTS_SMB_PORT", "445"))
     img = f"docker run --name {container} --detach -p 139:139 -p {port}:445 dperson/samba"  # noqa: E231 E501
     cmd = f"{img} {cfg}"
     try:
@@ -448,7 +448,7 @@ def smb_container():
 
 @pytest.fixture
 def smb_url(smb_container):
-    smb_url = "smb://{username}:{password}@{host}/home/"
+    smb_url = "smb://{username}:{password}@{host}:{port}/home/"
     smb_url = smb_url.format(**smb_container)
     return smb_url
 


### PR DESCRIPTION
When the smb port is already in use, smb tests fail.
This PR provides an easy way to run smb tests on a different port via setting `UPATH_TESTS_SMB_PORT`