### PR TITLE
Support relative paths

### DIFF
--- a/upath/_protocol.py
+++ b/upath/_protocol.py
@@ -105,7 +105,12 @@ def compatible_protocol(
     *args: str | os.PathLike[str] | PurePath | JoinablePath,
 ) -> bool:
     """check if UPath protocols are compatible"""
+    from upath.core import UPath
+
     for arg in args:
+        if isinstance(arg, UPath) and not arg.is_absolute():
+            # relative UPath are always compatible
+            continue
         other_protocol = get_upath_protocol(arg)
         # consider protocols equivalent if they match up to the first "+"
         other_protocol = other_protocol.partition("+")[0]

--- a/upath/core.py
+++ b/upath/core.py
@@ -481,6 +481,8 @@ class UPath(_UPathMixin, OpenablePath):
         return self._chain_parser.chain(self._chain.to_list())[0]
 
     def __repr__(self) -> str:
+        if self._relative_base is not None:
+            return f"<relative {type(self).__name__} {str(self)!r}>"
         return f"{type(self).__name__}({self.path!r}, protocol={self._protocol!r})"
 
     # === JoinablePath overrides ======================================

--- a/upath/core.py
+++ b/upath/core.py
@@ -537,6 +537,24 @@ class UPath(_UPathMixin, OpenablePath):
             return ""
         return self.drive + self.root
 
+    @property
+    def parent(self) -> Self:
+        if self._relative_base is not None:
+            if str(self) == ".":
+                return self
+            else:
+                # this needs to be revisited...
+                pth = type(self)(
+                    self._relative_base,
+                    str(self),
+                    protocol=self._protocol,
+                    **self._storage_options,
+                )
+                parent = pth.parent
+                parent._relative_base = self._relative_base
+                return parent
+        return super().parent
+
     # === ReadablePath attributes =====================================
 
     @property

--- a/upath/core.py
+++ b/upath/core.py
@@ -447,13 +447,18 @@ class UPath(_UPathMixin, OpenablePath):
     parser: UPathParser = LazyFlavourDescriptor()  # type: ignore[assignment]
 
     def with_segments(self, *pathsegments: JoinablePathLike) -> Self:
+        # we change joinpath behavior if called from a relative path
+        # this is not fully ideal, but currently the best way to move forward
+        if is_relative := self._relative_base is not None:
+            pathsegments = (self._relative_base, *pathsegments)
+
         new_instance = type(self)(
             *pathsegments,
             protocol=self._protocol,
             **self._storage_options,
         )
-        # Preserve _relative_base if it was set
-        if hasattr(self, "_relative_base") and self._relative_base is not None:
+
+        if is_relative:
             new_instance._relative_base = self._relative_base
         return new_instance
 

--- a/upath/core.py
+++ b/upath/core.py
@@ -555,6 +555,19 @@ class UPath(_UPathMixin, OpenablePath):
                 return parent
         return super().parent
 
+    @property
+    def parents(self) -> Sequence[Self]:
+        if self._relative_base is not None:
+            parents = []
+            parent = self
+            while True:
+                if str(parent) == ".":
+                    break
+                parent = parent.parent
+                parents.append(parent)
+            return parents
+        return super().parents
+
     # === ReadablePath attributes =====================================
 
     @property

--- a/upath/core.py
+++ b/upath/core.py
@@ -973,10 +973,14 @@ class UPath(_UPathMixin, OpenablePath):
 
     @property
     def drive(self) -> str:
+        if self._relative_base is not None:
+            return ""
         return self.parser.splitroot(str(self))[0]
 
     @property
     def root(self) -> str:
+        if self._relative_base is not None:
+            return ""
         return self.parser.splitroot(str(self))[1]
 
     def __reduce__(self):

--- a/upath/core.py
+++ b/upath/core.py
@@ -184,12 +184,6 @@ class _UPathMixin(metaclass=_UPathMeta):
     def _relative_base(self, value: str | None) -> None:
         raise NotImplementedError
 
-    @classmethod
-    @abstractmethod
-    def cwd(cls) -> Self:
-        """Return a new path representing the current working directory."""
-        raise NotImplementedError
-
     # === upath.UPath PUBLIC ADDITIONAL API ===========================
 
     @property
@@ -219,7 +213,7 @@ class _UPathMixin(metaclass=_UPathMeta):
         if self._relative_base is not None:
             # For relative paths, we need to resolve to absolute path
             try:
-                current_dir = self.cwd()
+                current_dir = self.cwd()  # type: ignore[attr-defined]
             except NotImplementedError:
                 raise NotImplementedError(
                     f"Filesystem operations on relative {self.__class__.__name__} "

--- a/upath/core.py
+++ b/upath/core.py
@@ -525,6 +525,8 @@ class UPath(_UPathMixin, OpenablePath):
 
     @property
     def anchor(self) -> str:
+        if self._relative_base is not None:
+            return ""
         return self.drive + self.root
 
     # === ReadablePath attributes =====================================
@@ -990,6 +992,10 @@ class UPath(_UPathMixin, OpenablePath):
         return _make_instance, (type(self), args, kwargs)
 
     def as_uri(self) -> str:
+        if self._relative_base is not None:
+            raise ValueError(
+                f"relative path can't be expressed as a {self.protocol} URI"
+            )
         return str(self)
 
     def as_posix(self) -> str:

--- a/upath/implementations/_experimental.py
+++ b/upath/implementations/_experimental.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from upath.registry import get_upath_class
+
+if TYPE_CHECKING:
+    from upath import UPath
+
+
+def __getattr__(name: str) -> type[UPath]:
+    if name.startswith("_") and name.endswith("Path"):
+        protocol = name[1:-4].lower()
+        cls = get_upath_class(protocol, fallback=False)
+        assert cls is not None
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -93,6 +93,13 @@ class GCSPath(CloudPath):
             if "unexpected keyword argument 'create_parents'" in str(err):
                 self.fs.mkdir(self.path)
 
+    def exists(self, *, follow_symlinks=True):
+        # required for gcsfs<2025.5.0, see: https://github.com/fsspec/gcsfs/pull/676
+        path = self.path
+        if len(path) > 1:
+            path = path.removesuffix(self.root)
+        return self.fs.exists(path)
+
 
 class S3Path(CloudPath):
     __slots__ = ()

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -46,6 +46,8 @@ class CloudPath(UPath):
 
     @property
     def root(self) -> str:
+        if self._relative_base is not None:
+            return ""
         return self.parser.sep
 
     def mkdir(

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -50,6 +50,14 @@ class CloudPath(UPath):
             return ""
         return self.parser.sep
 
+    def __vfspath__(self):
+        path = super().__vfspath__()
+        if self._relative_base is None:
+            drive = self.parser.splitdrive(path)[0]
+            if drive and path == f"{self.protocol}://{drive}":
+                return f"{path}{self.root}"
+        return path
+
     def mkdir(
         self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False
     ) -> None:

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -60,11 +60,6 @@ class CloudPath(UPath):
             raise NotADirectoryError(str(self))
         yield from super().iterdir()
 
-    def relative_to(self, other, /, *_deprecated, walk_up=False):
-        # use the parent implementation for the ValueError logic
-        super().relative_to(other, *_deprecated, walk_up=False)
-        return self
-
 
 class GCSPath(CloudPath):
     __slots__ = ()

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -71,11 +71,13 @@ class LocalPath(_UPathMixin, pathlib.Path):
         "_chain",
         "_chain_parser",
         "_fs_cached",
+        "_relative_base",
     )
     if TYPE_CHECKING:
         _chain: Chain
         _chain_parser: FSSpecChainParser
         _fs_cached: AbstractFileSystem
+        _relative_base: str | None
 
     parser = os.path  # type: ignore[misc,assignment]
 
@@ -174,6 +176,10 @@ class LocalPath(_UPathMixin, pathlib.Path):
         if not compatible_protocol("", other):
             raise ValueError("can't combine incompatible UPath protocols")
         return super().__rtruediv__(other)
+
+    @classmethod
+    def cwd(cls) -> Self:
+        return cls(super().cwd())
 
 
 UPath.register(LocalPath)

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -232,5 +232,13 @@ class FilePath(UPath):
     def _url(self) -> SplitResult:
         return SplitResult._make((self.protocol, "", self.path, "", ""))
 
+    @classmethod
+    def cwd(cls) -> Self:
+        return cls(os.getcwd(), protocol="file")
+
+    @classmethod
+    def home(cls) -> Self:
+        return cls(os.path.expanduser("~"), protocol="file")
+
 
 LocalPath.register(FilePath)

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -165,17 +165,17 @@ class LocalPath(_UPathMixin, pathlib.Path):
     def joinpath(self, *other) -> Self:
         if not compatible_protocol("", *other):
             raise ValueError("can't combine incompatible UPath protocols")
-        return super().joinpath(*other)
+        return super().joinpath(*map(str, other))
 
     def __truediv__(self, other) -> Self:
         if not compatible_protocol("", other):
             raise ValueError("can't combine incompatible UPath protocols")
-        return super().__truediv__(other)
+        return super().__truediv__(str(other))
 
     def __rtruediv__(self, other) -> Self:
         if not compatible_protocol("", other):
             raise ValueError("can't combine incompatible UPath protocols")
-        return super().__rtruediv__(other)
+        return super().__rtruediv__(str(other))
 
 
 UPath.register(LocalPath)

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -177,10 +177,6 @@ class LocalPath(_UPathMixin, pathlib.Path):
             raise ValueError("can't combine incompatible UPath protocols")
         return super().__rtruediv__(other)
 
-    @classmethod
-    def cwd(cls) -> Self:
-        return cls(super().cwd())
-
 
 UPath.register(LocalPath)
 

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -165,17 +165,30 @@ class LocalPath(_UPathMixin, pathlib.Path):
     def joinpath(self, *other) -> Self:
         if not compatible_protocol("", *other):
             raise ValueError("can't combine incompatible UPath protocols")
-        return super().joinpath(*map(str, other))
+        return super().joinpath(
+            *(
+                str(o) if isinstance(o, UPath) and not o.is_absolute() else o
+                for o in other
+            )
+        )
 
     def __truediv__(self, other) -> Self:
         if not compatible_protocol("", other):
             raise ValueError("can't combine incompatible UPath protocols")
-        return super().__truediv__(str(other))
+        return super().__truediv__(
+            str(other)
+            if isinstance(other, UPath) and not other.is_absolute()
+            else other
+        )
 
     def __rtruediv__(self, other) -> Self:
         if not compatible_protocol("", other):
             raise ValueError("can't combine incompatible UPath protocols")
-        return super().__rtruediv__(str(other))
+        return super().__rtruediv__(
+            str(other)
+            if isinstance(other, UPath) and not other.is_absolute()
+            else other
+        )
 
 
 UPath.register(LocalPath)

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -215,7 +215,7 @@ def get_upath_class(
         if not fallback:
             return None
         try:
-            _ = get_filesystem_class(protocol)
+            fs_cls = get_filesystem_class(protocol)
         except ValueError:
             return None  # this is an unknown protocol
         else:
@@ -226,4 +226,5 @@ def get_upath_class(
                 UserWarning,
                 stacklevel=2,
             )
-            return upath.UPath
+            prefix = fs_cls.__name__.lower().removesuffix("filesystem").title()
+            return type(f"{prefix}Path", (upath.UPath,), {})

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -215,7 +215,7 @@ def get_upath_class(
         if not fallback:
             return None
         try:
-            fs_cls = get_filesystem_class(protocol)
+            get_filesystem_class(protocol)
         except ValueError:
             return None  # this is an unknown protocol
         else:
@@ -226,5 +226,13 @@ def get_upath_class(
                 UserWarning,
                 stacklevel=2,
             )
-            prefix = fs_cls.__name__.lower().removesuffix("filesystem").title()
-            return type(f"{prefix}Path", (upath.UPath,), {})
+            import upath.implementations._experimental as upath_experimental
+
+            cls_name = f"_{protocol.title()}Path"
+            cls = type(
+                cls_name,
+                (upath.UPath,),
+                {"__module__": "upath.implementations._experimental"},
+            )
+            setattr(upath_experimental, cls_name, cls)
+            return cls

--- a/upath/tests/implementations/test_local.py
+++ b/upath/tests/implementations/test_local.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from upath import UPath
@@ -15,6 +17,16 @@ class TestFSSpecLocal(BaseTests):
     def test_is_LocalPath(self):
         assert isinstance(self.path, LocalPath)
 
+    def test_cwd(self):
+        cwd = type(self.path).cwd()
+        assert isinstance(cwd, LocalPath)
+        assert cwd.path == Path.cwd().as_posix()
+
+    def test_home(self):
+        cwd = type(self.path).home()
+        assert isinstance(cwd, LocalPath)
+        assert cwd.path == Path.home().as_posix()
+
 
 @xfail_if_version("fsspec", lt="2023.10.0", reason="requires fsspec>=2023.10.0")
 class TestRayIOFSSpecLocal(BaseTests):
@@ -25,3 +37,13 @@ class TestRayIOFSSpecLocal(BaseTests):
 
     def test_is_LocalPath(self):
         assert isinstance(self.path, LocalPath)
+
+    def test_cwd(self):
+        cwd = type(self.path).cwd()
+        assert isinstance(cwd, LocalPath)
+        assert cwd.path == Path.cwd().as_posix()
+
+    def test_home(self):
+        cwd = type(self.path).home()
+        assert isinstance(cwd, LocalPath)
+        assert cwd.path == Path.home().as_posix()

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -52,7 +52,7 @@ class TestUPathS3(BaseTests):
             self.path.joinpath("file1.txt").rmdir()
 
     def test_relative_to(self):
-        assert "s3://test_bucket/file.txt" == str(
+        assert "file.txt" == str(
             UPath("s3://test_bucket/file.txt").relative_to(UPath("s3://test_bucket"))
         )
 

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -78,7 +78,7 @@ class TestUPathS3(BaseTests):
 
     def test_creating_s3path_with_bucket(self):
         path = UPath("s3://", bucket="bucket", anon=self.anon, **self.s3so)
-        assert str(path) == "s3://bucket"
+        assert str(path) == "s3://bucket/"
 
     def test_iterdir_with_plus_in_name(self, s3_with_plus_chr_name):
         bucket, anon, s3so = s3_with_plus_chr_name

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -340,7 +340,7 @@ def test_copy_path_append_kwargs():
 
 
 def test_relative_to():
-    assert "s3://test_bucket/file.txt" == str(
+    assert "file.txt" == str(
         UPath("s3://test_bucket/file.txt").relative_to(UPath("s3://test_bucket"))
     )
 

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -64,16 +64,18 @@ class TestUpath(BaseTests):
         pass
 
     def test_cwd(self):
-        pth = type(self.path).cwd()
-        assert str(pth) == os.getcwd()
-        assert isinstance(pth, pathlib.Path)
-        assert isinstance(pth, UPath)
+        with pytest.raises(
+            NotImplementedError,
+            match=r".+Path[.]cwd\(\) is unsupported",
+        ):
+            type(self.path).cwd()
 
     def test_home(self):
-        pth = type(self.path).home()
-        assert str(pth) == os.path.expanduser("~")
-        assert isinstance(pth, pathlib.Path)
-        assert isinstance(pth, UPath)
+        with pytest.raises(
+            NotImplementedError,
+            match=r".+Path[.]home\(\) is unsupported",
+        ):
+            type(self.path).home()
 
     @xfail_if_version("fsspec", reason="", ge="2024.2.0")
     def test_iterdir_no_dir(self):

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -210,3 +210,18 @@ def test_s3_relative_paths():
 
     assert not rel.is_absolute()
     assert str(rel) == "dir/file.txt"
+
+
+@pytest.fixture
+def rel_path():
+    p = UPath("memory:///foo/bar/baz.txt")
+    root = UPath("memory:///foo")
+    yield p.relative_to(root)
+
+
+def test_relative_path_as_uri(rel_path):
+    with pytest.raises(
+        ValueError,
+        "relative path can't be expressed as a {rel_path.protocol} URI",
+    ):
+        rel_path.as_uri()

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -374,7 +374,7 @@ def test_relative_path_stem_suffix_name(rel_path):
     assert rel_path.with_name("other.txt").name == "other.txt"
     assert rel_path.with_stem("other").name == "other.txt"
     assert rel_path.with_suffix(".md").name == "baz.md"
-    assert rel_path.with_suffix([".tar.gz"]).suffixes == [".tar", ".gz"]
+    assert rel_path.with_suffix(".tar.gz").suffixes == [".tar", ".gz"]
 
 
 # 'fs',

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -491,7 +491,7 @@ def test_relative_path_parents(uri, base, expected_parents_parts):
 )
 def test_home_works_for_local_paths(protocol, pth, base):
     rel = UPath(pth, protocol=protocol).relative_to(UPath(base, protocol=protocol))
-    assert rel.home() == UPath.home()
+    assert os.fspath(rel.home()) == os.fspath(UPath.home())
 
 
 @pytest.mark.parametrize(

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -2,6 +2,7 @@
 
 import os
 import pickle
+import re
 import tempfile
 
 import pytest
@@ -66,12 +67,13 @@ def test_filesystem_operations_fail_without_cwd():
     # Memory filesystem doesn't implement cwd(), so these should fail
     with pytest.raises(
         NotImplementedError,
-        match="require cwd\\(\\) to be implemented",
+        match=re.escape("MemoryPath.cwd() is unsupported"),
     ):
         _ = rel.path
 
     with pytest.raises(
-        NotImplementedError, match="require cwd\\(\\) to be implemented"
+        NotImplementedError,
+        match=re.escape("MemoryPath.cwd() is unsupported"),
     ):
         rel.exists()
 
@@ -156,7 +158,7 @@ def test_absolute_method_behavior():
 
     with pytest.raises(
         NotImplementedError,
-        match="require cwd\\(\\) to be implemented",
+        match=re.escape("MemoryPath.cwd() is unsupported"),
     ):
         rel.absolute()
 
@@ -222,6 +224,89 @@ def rel_path():
 def test_relative_path_as_uri(rel_path):
     with pytest.raises(
         ValueError,
-        "relative path can't be expressed as a {rel_path.protocol} URI",
+        match=f"relative path can't be expressed as a {rel_path.protocol} URI",
     ):
         rel_path.as_uri()
+
+
+@pytest.mark.parametrize(
+    "method_args",
+    [
+        pytest.param(("absolute", ()), id="absolute"),
+        pytest.param(("chmod", (0o777,)), id="chmod"),
+        pytest.param(("cwd", ()), id="cwd"),
+        pytest.param(("exists", ()), id="exists"),
+        pytest.param(("glob", ("*.txt",)), id="glob"),
+        pytest.param(("group", ()), id="group"),
+        pytest.param(("is_dir", ()), id="is_dir"),
+        pytest.param(("is_file", ()), id="is_file"),
+        pytest.param(("is_symlink", ()), id="is_symlink"),
+        pytest.param(("iterdir", ()), id="iterdir"),
+        pytest.param(("open", ()), id="open"),
+        pytest.param(("owner", ()), id="owner"),
+        pytest.param(("read_bytes", ()), id="read_bytes"),
+        pytest.param(("read_text", ()), id="read_text"),
+        pytest.param(("readlink", ()), id="readlink"),
+        pytest.param(("rename", ("a/b/c",)), id="rename"),
+        pytest.param(("replace", ("...",)), id="replace"),
+        pytest.param(("rglob", ("*.txt",)), id="rglob"),
+        pytest.param(("rmdir", ()), id="rmdir"),
+        pytest.param(("samefile", ("...",)), id="samefile"),
+        pytest.param(("stat", ()), id="stat"),
+        pytest.param(("symlink_to", ("...",)), id="symlink_to"),
+        pytest.param(("touch", ()), id="touch"),
+        pytest.param(("unlink", ()), id="unlink"),
+        pytest.param(("write_bytes", (b"data",)), id="write_bytes"),
+        pytest.param(("write_text", ("data",)), id="write_text"),
+    ],
+)
+def test_path_operations_disabled_without_cwd(rel_path, method_args):
+    """UPaths without .cwd() implementation should not allow path operations."""
+    method, args = method_args
+
+    with pytest.raises(NotImplementedError):
+        # next only needs to be called for iterdir and glob/rglob
+        # but the other raise already in the getattr call
+        next(getattr(rel_path, method)(*args))
+
+
+# 'anchor',
+# 'as_posix',
+# 'as_uri',
+# 'drive',
+# 'expanduser',
+# 'fs',
+# 'home',
+# 'is_absolute',
+# 'is_relative_to',
+# 'joinpath',
+# 'joinuri',
+# 'lchmod',
+# 'link_to',
+# 'lstat',
+# 'match',
+# 'mkdir',
+# 'name',
+# 'parent',
+# 'parents',
+# 'parser',
+# 'parts',
+# 'path',
+# 'protocol',
+# 'relative_to',
+# 'root',
+# 'stem',
+# 'storage_options',
+# 'suffix',
+# 'suffixes',
+# 'with_name',
+# 'with_segments',
+# 'with_stem',
+# 'with_suffix',
+# 'is_block_device',
+# 'is_char_device',
+# 'is_fifo',
+# 'is_mount',
+# 'is_reserved',
+# 'is_socket',
+# 'resolve',

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -464,6 +464,7 @@ def test_relative_path_parent(protocol, pth, base, expected_parent):
         ("file:///foo/bar/baz/qux.txt", "file:///foo", [("bar", "baz"), ("bar",), ()]),
         ("s3://bucket/foo/bar/baz/", "s3://bucket/", [("foo", "bar"), ("foo",), ()]),
         ("gcs://bucket/foo/bar/baz", "gcs://bucket/", [("foo", "bar"), ("foo",), ()]),
+        ("az://bucket/foo/bar/baz", "az://bucket/", [("foo", "bar"), ("foo",), ()]),
         (
             "memory:///foo/bar/baz/qux.txt",
             "memory:///foo",

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -30,7 +30,7 @@ def test_basic_relative_path_creation(protocol, pth, base, rel):
     rel_pth = UPath(pth, protocol=protocol).relative_to(UPath(base, protocol=protocol))
 
     assert not rel_pth.is_absolute()
-    assert str(rel_pth) == rel
+    assert rel_pth.as_posix() == rel
 
 
 def test_relative_path_validation():
@@ -38,11 +38,11 @@ def test_relative_path_validation():
     p = UPath("memory:///foo/bar")
 
     # Different protocols should fail
-    with pytest.raises(ValueError, match="different storage_options"):
+    with pytest.raises(ValueError, match="incompatible protocols"):
         p.relative_to(UPath("s3://bucket"))
 
     # Different storage options should fail
-    with pytest.raises(ValueError, match="different storage_options"):
+    with pytest.raises(ValueError, match="incompatible storage_options"):
         UPath("s3://bucket/file", anon=True).relative_to(
             UPath("s3://bucket", anon=False)
         )

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -67,13 +67,17 @@ def test_filesystem_operations_fail_without_cwd():
     # Memory filesystem doesn't implement cwd(), so these should fail
     with pytest.raises(
         NotImplementedError,
-        match=re.escape("MemoryPath.cwd() is unsupported"),
+        match=re.escape(
+            "fsspec paths can not be relative and MemoryPath.cwd() is unsupported"
+        ),
     ):
         _ = rel.path
 
     with pytest.raises(
         NotImplementedError,
-        match=re.escape("MemoryPath.cwd() is unsupported"),
+        match=re.escape(
+            "fsspec paths can not be relative and MemoryPath.cwd() is unsupported"
+        ),
     ):
         rel.exists()
 
@@ -342,10 +346,39 @@ def test_relative_path_parts_property(protocol, path, base, expected_parts):
     assert rel.parts == expected_parts
 
 
-# 'expanduser',
+def test_relative_path_is_something(rel_path):
+    assert rel_path.is_block_device() is False
+    assert rel_path.is_char_device() is False
+    assert rel_path.is_fifo() is False
+    assert rel_path.is_mount() is False
+    assert rel_path.is_reserved() is False
+    assert rel_path.is_socket() is False
+
+
+def test_relative_path_hashable():
+    x = UPath("memory:///a/b/c.txt")
+    y = x.relative_to(UPath("memory:///a"))
+    assert hash(y) != hash(x)
+
+
+def test_relative_path_expanduser_noop(rel_path):
+    # this should be revisited if we ever add ~ support to non-file protocols
+    assert rel_path == rel_path.expanduser()
+
+
+def test_relative_path_stem_suffix_name(rel_path):
+    assert rel_path.name == "baz.txt"
+    assert rel_path.stem == "baz"
+    assert rel_path.suffix == ".txt"
+    assert rel_path.suffixes == [".txt"]
+    assert rel_path.with_name("other.txt").name == "other.txt"
+    assert rel_path.with_stem("other").name == "other.txt"
+    assert rel_path.with_suffix(".md").name == "baz.md"
+    assert rel_path.with_suffix([".tar.gz"]).suffixes == [".tar", ".gz"]
+
+
 # 'fs',
 # 'home',
-# 'is_absolute',
 # 'is_relative_to',
 # 'joinpath',
 # 'joinuri',
@@ -354,25 +387,11 @@ def test_relative_path_parts_property(protocol, path, base, expected_parts):
 # 'lstat',
 # 'match',
 # 'mkdir',
-# 'name',
 # 'parent',
 # 'parents',
 # 'parser',
 # 'path',
 # 'protocol',
-# 'relative_to',
-# 'stem',
 # 'storage_options',
-# 'suffix',
-# 'suffixes',
-# 'with_name',
 # 'with_segments',
-# 'with_stem',
-# 'with_suffix',
-# 'is_block_device',
-# 'is_char_device',
-# 'is_fifo',
-# 'is_mount',
-# 'is_reserved',
-# 'is_socket',
 # 'resolve',

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -584,6 +584,36 @@ def test_relative_path_match(protocol, path, base):
     assert not rel.match("other.txt")
 
 
-# 'joinpath',
+@pytest.mark.parametrize(
+    "protocol,path,base",
+    [
+        ("", "/foo/bar/baz/qux.txt", "/foo"),
+        ("file", "/foo/bar/baz/qux.txt", "/foo"),
+        ("s3", "s3://bucket/foo/bar/baz/qux.txt", "s3://bucket/foo"),
+        ("gcs", "gcs://bucket/foo/bar/baz/qux.txt", "gcs://bucket/foo"),
+        ("memory", "memory:///foo/bar/baz/qux.txt", "memory:///foo"),
+        ("https", "https://host/foo/bar/baz/qux.txt", "https://host/foo"),
+    ],
+)
+def test_relative_path_joinpath(protocol, path, base):
+    """Test that joinpath works correctly for relative paths."""
+    rel = UPath(path, protocol=protocol).relative_to(UPath(base, protocol=protocol))
+
+    # Test joining with a single segment
+    assert str(rel) == "bar/baz/qux.txt"
+    joined = rel.joinpath("extra.txt")
+    assert str(joined) == "bar/baz/qux.txt/extra.txt"
+    assert not joined.is_absolute()
+
+    # Test joining with multiple segments
+    joined_multi = rel.joinpath("dir", "file.py")
+    assert str(joined_multi) == "bar/baz/qux.txt/dir/file.py"
+    assert not joined_multi.is_absolute()
+
+    # Test that the result is still relative with same base
+    assert joined.protocol == joined_multi.protocol == protocol
+    assert joined.storage_options == joined_multi.storage_options == rel.storage_options
+
+
 # 'joinuri',
 # 'with_segments',

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -270,10 +270,78 @@ def test_path_operations_disabled_without_cwd(rel_path, method_args):
         next(getattr(rel_path, method)(*args))
 
 
-# 'anchor',
-# 'as_posix',
-# 'as_uri',
-# 'drive',
+@pytest.mark.parametrize(
+    "protocol,path,base",
+    [
+        ("", "/foo/bar/baz.txt", "/foo"),
+        ("file", "/foo/bar/baz.txt", "/foo"),
+        ("s3", "s3://bucket/foo/bar/baz.txt", "s3://bucket/foo"),
+        ("gcs", "gcs://bucket/foo/bar/baz.txt", "gcs://bucket/foo"),
+        ("ftp", "ftp://user:pass@host/foo/bar/baz.txt", "ftp://user:pass@host/foo"),
+        ("http", "http://host/foo/bar/baz.txt", "http://host/foo"),
+        ("https", "https://host/foo/bar/baz.txt", "https://host/foo"),
+        ("memory", "memory:///foo/bar/baz.txt", "memory:///foo"),
+    ],
+)
+def test_drive_root_anchor_empty_for_relative_paths(protocol, path, base):
+    rel = UPath(path, protocol=protocol).relative_to(UPath(base, protocol=protocol))
+    assert (rel.drive, rel.root, rel.anchor) == ("", "", "")
+
+
+@pytest.mark.parametrize(
+    "protocol,path,base,expected_rel",
+    [
+        ("", "/foo/bar/baz.txt", "/foo", "bar/baz.txt"),
+        ("file", "/foo/bar/baz.txt", "/foo", "bar/baz.txt"),
+        ("s3", "s3://bucket/foo/bar/baz.txt", "s3://bucket/foo", "bar/baz.txt"),
+        ("gcs", "gcs://bucket/foo/bar/baz.txt", "gcs://bucket/foo", "bar/baz.txt"),
+        (
+            "ftp",
+            "ftp://user:pass@host/foo/bar/baz.txt",
+            "ftp://user:pass@host/foo",
+            "bar/baz.txt",
+        ),
+        ("http", "http://host/foo/bar/baz.txt", "http://host/foo", "bar/baz.txt"),
+        ("https", "https://host/foo/bar/baz.txt", "https://host/foo", "bar/baz.txt"),
+        ("memory", "memory:///foo/bar/baz.txt", "memory:///foo", "bar/baz.txt"),
+    ],
+)
+def test_relative_path_properties(protocol, path, base, expected_rel):
+    rel = UPath(path, protocol=protocol).relative_to(UPath(base, protocol=protocol))
+
+    assert not rel.is_absolute()
+    assert rel.as_posix() == expected_rel
+    assert rel.parts == tuple(expected_rel.split("/"))
+
+
+@pytest.mark.parametrize(
+    "protocol,path,base,expected_parts",
+    [
+        ("", "/foo/bar/baz.txt", "/foo", ("bar", "baz.txt")),
+        ("file", "/foo/bar/baz.txt", "/foo", ("bar", "baz.txt")),
+        ("s3", "s3://bucket/foo/bar/baz.txt", "s3://bucket/foo", ("bar", "baz.txt")),
+        ("gcs", "gcs://bucket/foo/bar/baz.txt", "gcs://bucket/foo", ("bar", "baz.txt")),
+        (
+            "ftp",
+            "ftp://user:pass@host/foo/bar/baz.txt",
+            "ftp://user:pass@host/foo",
+            ("bar", "baz.txt"),
+        ),
+        ("http", "http://host/foo/bar/baz.txt", "http://host/foo", ("bar", "baz.txt")),
+        (
+            "https",
+            "https://host/foo/bar/baz.txt",
+            "https://host/foo",
+            ("bar", "baz.txt"),
+        ),
+        ("memory", "memory:///foo/bar/baz.txt", "memory:///foo", ("bar", "baz.txt")),
+    ],
+)
+def test_relative_path_parts_property(protocol, path, base, expected_parts):
+    rel = UPath(path, protocol=protocol).relative_to(UPath(base, protocol=protocol))
+    assert rel.parts == expected_parts
+
+
 # 'expanduser',
 # 'fs',
 # 'home',
@@ -290,11 +358,9 @@ def test_path_operations_disabled_without_cwd(rel_path, method_args):
 # 'parent',
 # 'parents',
 # 'parser',
-# 'parts',
 # 'path',
 # 'protocol',
 # 'relative_to',
-# 'root',
 # 'stem',
 # 'storage_options',
 # 'suffix',

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -492,7 +492,8 @@ def test_relative_path_parents(uri, base, expected_parents_parts):
 )
 def test_home_works_for_local_paths(protocol, pth, base):
     rel = UPath(pth, protocol=protocol).relative_to(UPath(base, protocol=protocol))
-    assert rel.home().as_posix() == UPath.home().as_posix()
+    prefix = f"{protocol}://" if protocol else ""
+    assert rel.home().as_posix() == prefix + UPath.home().as_posix()
 
 
 @pytest.mark.parametrize(
@@ -550,7 +551,10 @@ def test_relpath_path_resolve(tmp_path, protocol, monkeypatch):
     assert rel.as_posix() == "a/b/c/d/../../file.txt"
 
     resolved = rel.resolve()
-    assert resolved.as_posix() == (tmp_path / "a" / "b" / "file.txt").as_posix()
+    prefix = f"{protocol}://" if protocol else ""
+    assert (
+        resolved.as_posix() == prefix + (tmp_path / "a" / "b" / "file.txt").as_posix()
+    )
     assert resolved.read_text() == "data"
     assert resolved.is_absolute()
     assert resolved.exists()

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -612,7 +612,7 @@ def test_relative_path_joinpath(protocol, path, base):
 
     # Test joining with multiple segments
     joined_multi = rel.joinpath("dir", "file.py")
-    assert str(joined_multi) == "bar/baz/qux.txt/dir/file.py"
+    assert joined_multi.as_posix() == "bar/baz/qux.txt/dir/file.py"
     assert not joined_multi.is_absolute()
 
     # Test that the result is still relative with same base

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -657,7 +657,7 @@ def test_join_local_absolute_path_to_relative(protocol, path, base, tmp_path):
 def test_join_fsspec_absolute_path_to_relative(protocol, path):
     p = UPath(path, protocol=protocol)
 
-    x = p.joinpath(Path("a/b/c"))
+    x = p.joinpath(Path("a/b/c").as_posix())
     assert x.path.endswith("foo/bar/a/b/c")
 
 

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -246,6 +246,9 @@ def test_relative_path_as_uri(rel_path):
         pytest.param(("is_file", ()), id="is_file"),
         pytest.param(("is_symlink", ()), id="is_symlink"),
         pytest.param(("iterdir", ()), id="iterdir"),
+        pytest.param(("lchmod", (0o777,)), id="lchmod"),
+        pytest.param(("lstat", ()), id="lstat"),
+        pytest.param(("mkdir", ()), id="mkdir"),
         pytest.param(("open", ()), id="open"),
         pytest.param(("owner", ()), id="owner"),
         pytest.param(("read_bytes", ()), id="read_bytes"),
@@ -377,16 +380,30 @@ def test_relative_path_stem_suffix_name(rel_path):
     assert rel_path.with_suffix(".tar.gz").suffixes == [".tar", ".gz"]
 
 
+@pytest.mark.parametrize(
+    "protocol,pth,base,expected_parent",
+    [
+        ("", "/foo/bar/baz.txt", "/foo", "bar"),
+        ("", "/foo", "/foo", "."),
+        ("file", "/foo/bar/baz.txt", "/foo", "bar"),
+        ("file", "/foo/bar", "/foo/bar", "."),
+        ("s3", "s3://bucket/foo/bar/baz.txt", "s3://bucket/foo", "bar"),
+        ("s3", "s3://bucket/foo/bar/", "s3://bucket/foo/bar", "."),
+        ("gcs", "gcs://bucket/foo/bar/baz.txt", "gcs://bucket/foo", "bar"),
+        ("gcs", "gcs://bucket/foo/bar/", "gcs://bucket/foo", "."),
+        ("memory", "memory:///foo/bar/baz.txt", "memory:///foo", "bar"),
+        ("memory", "memory:///foo/bar", "memory:///foo", "."),
+    ],
+)
+def test_relative_path_parent(protocol, pth, base, expected_parent):
+    rel = UPath(pth, protocol=protocol).relative_to(UPath(base, protocol=protocol))
+    assert str(rel.parent) == expected_parent
+
+
 # 'fs',
 # 'home',
-# 'is_relative_to',
 # 'joinpath',
 # 'joinuri',
-# 'lchmod',
-# 'link_to',
-# 'lstat',
-# 'match',
-# 'mkdir',
 # 'parent',
 # 'parents',
 # 'parser',
@@ -395,3 +412,4 @@ def test_relative_path_stem_suffix_name(rel_path):
 # 'storage_options',
 # 'with_segments',
 # 'resolve',
+# 'match',

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -492,7 +492,7 @@ def test_relative_path_parents(uri, base, expected_parents_parts):
 )
 def test_home_works_for_local_paths(protocol, pth, base):
     rel = UPath(pth, protocol=protocol).relative_to(UPath(base, protocol=protocol))
-    assert os.fspath(rel.home()) == os.fspath(UPath.home())
+    assert rel.home().as_posix() == UPath.home().as_posix()
 
 
 @pytest.mark.parametrize(
@@ -547,10 +547,10 @@ def test_relpath_path_resolve(tmp_path, protocol, monkeypatch):
         UPath("/xyz", protocol=protocol)
     )
 
-    assert str(rel) == "a/b/c/d/../../file.txt"
+    assert rel.as_posix() == "a/b/c/d/../../file.txt"
 
     resolved = rel.resolve()
-    assert os.fspath(resolved) == os.fspath(tmp_path / "a" / "b" / "file.txt")
+    assert resolved.as_posix() == (tmp_path / "a" / "b" / "file.txt").as_posix()
     assert resolved.read_text() == "data"
     assert resolved.is_absolute()
     assert resolved.exists()
@@ -571,7 +571,7 @@ def test_relative_path_match(protocol, path, base):
     """Test that match works correctly for relative paths."""
     rel = UPath(path, protocol=protocol).relative_to(UPath(base, protocol=protocol))
 
-    assert str(rel) == "bar/baz/qux.txt"
+    assert rel.as_posix() == "bar/baz/qux.txt"
 
     # Should match patterns that match the relative path
     assert rel.match("bar/baz/qux.txt")
@@ -601,9 +601,9 @@ def test_relative_path_joinpath(protocol, path, base):
     rel = UPath(path, protocol=protocol).relative_to(UPath(base, protocol=protocol))
 
     # Test joining with a single segment
-    assert str(rel) == "bar/baz/qux.txt"
+    assert rel.as_posix() == "bar/baz/qux.txt"
     joined = rel.joinpath("extra.txt")
-    assert str(joined) == "bar/baz/qux.txt/extra.txt"
+    assert joined.as_posix() == "bar/baz/qux.txt/extra.txt"
     assert not joined.is_absolute()
 
     # Test joining with multiple segments


### PR DESCRIPTION
Replaces #215
Closes #214
Closes #184
Closes #170 

WIP implementation of relative path handling.

# TODO

- [x] If a UPath subclass does not implement `.cwd()` all file operations should be disabled for relative paths
- [x] Tests for all UPath attributes / methods for relative paths
- [x] Tests for joining between remote and local relative paths