### PR TITLE
Fix upath suffixes

### DIFF
--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -362,7 +362,7 @@ class WrappedFileSystemFlavour(UPathParser):  # (pathlib_abc.FlavourBase)
             return os.path.splitext(path)
         else:
             path, sep, name = path.rpartition(self.sep)
-            if name:
+            if "." in name:
                 stem, dot, ext = name.rpartition(".")
                 suffix = dot + ext
             else:

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -447,6 +447,22 @@ class BaseTests:
         path = path.with_suffix(".zip")
         assert path.suffix == ".zip"
 
+    def test_suffix(self):
+        path = self.path / "no_suffix"
+        assert path.suffix == ""
+        path = self.path / "file.txt"
+        assert path.suffix == ".txt"
+        path = self.path / "archive.tar.gz"
+        assert path.suffix == ".gz"
+
+    def test_suffixes(self):
+        path = self.path / "no_suffix"
+        assert path.suffixes == []
+        path = self.path / "file.txt"
+        assert path.suffixes == [".txt"]
+        path = self.path / "archive.tar.gz"
+        assert path.suffixes == [".tar", ".gz"]
+
     def test_with_stem(self):
         if sys.version_info < (3, 9):
             pytest.skip("with_stem only available on py3.9+")

--- a/upath/tests/implementations/test_data.py
+++ b/upath/tests/implementations/test_data.py
@@ -174,6 +174,12 @@ class TestUPathDataPath(BaseTests):
         with pytest.raises(NotImplementedError):
             self.path.with_suffix(".new")
 
+    def test_suffix(self):
+        assert self.path.suffix == ""
+
+    def test_suffixes(self):
+        assert self.path.suffixes == []
+
     def test_with_stem(self):
         with pytest.raises(NotImplementedError):
             self.path.with_stem("newname")


### PR DESCRIPTION
Fixes incorrect behavior for `.suffix` and `.suffixes` for non-local upaths.