### PR TITLE
Fix chained paths access

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -234,9 +234,8 @@ class _UPathMixin(metaclass=_UPathMeta):
                 path = str(current_dir)
             else:
                 path = current_dir.parser.join(str(self), self_path)
-        else:
-            path = str(self)
-        return self.parser.strip_protocol(path)
+            return self.parser.strip_protocol(path)
+        return self._chain.active_path
 
     def joinuri(self, uri: JoinablePathLike) -> UPath:
         """Join with urljoin behavior for UPath instances"""

--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -58,6 +58,13 @@ class CloudPath(UPath):
                 return f"{path}{self.root}"
         return path
 
+    @property
+    def path(self) -> str:
+        self_path = super().path
+        if self._relative_base is None and self.parser.sep not in self_path:
+            return self_path + self.root
+        return self_path
+
     def mkdir(
         self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False
     ) -> None:

--- a/upath/implementations/http.py
+++ b/upath/implementations/http.py
@@ -41,6 +41,11 @@ class HTTPPath(UPath):
         sr = urlsplit(super().__str__())
         return sr._replace(path=sr.path or "/").geturl()
 
+    @property
+    def path(self) -> str:
+        sr = urlsplit(super().path)
+        return sr._replace(path=sr.path or "/").geturl()
+
     def is_file(self) -> bool:
         try:
             next(super().iterdir())

--- a/upath/tests/test_chain.py
+++ b/upath/tests/test_chain.py
@@ -29,13 +29,16 @@ CURRENT_DRIVE = os.path.splitdrive(Path.cwd().as_posix())[0]
     [
         ("simplecache::file:///tmp", "/tmp"),
         pytest.param(
-            "zip://file.txt::file:///tmp.zip", "file.txt", marks=skip_on_windows(None)
+            "zip://file.txt::file:///tmp.zip",
+            "file.txt",
+            marks=skip_on_windows(None),
         ),
         pytest.param(
             "zip://file.txt::file:///tmp.zip",
             f"{CURRENT_DRIVE}/file.txt",
             marks=only_on_windows(None),
         ),
+        ("zip://a/b/c.txt::simplecache::memory://zipfile.zip", "a/b/c.txt"),
     ],
 )
 def test_chaining_upath_path(urlpath, expected):

--- a/upath/tests/test_chain.py
+++ b/upath/tests/test_chain.py
@@ -5,8 +5,6 @@ import pytest
 from fsspec.implementations.memory import MemoryFileSystem
 
 from upath import UPath
-from upath.tests.utils import only_on_windows
-from upath.tests.utils import skip_on_windows
 
 
 @pytest.mark.parametrize(
@@ -21,24 +19,26 @@ def test_chaining_upath_protocol(urlpath, expected):
     assert pth.protocol == expected
 
 
-CURRENT_DRIVE = os.path.splitdrive(Path.cwd().as_posix())[0]
+def add_current_drive_on_windows(pth: str) -> str:
+    drive = os.path.splitdrive(Path.cwd().as_posix())[0]
+    return f"{drive}{pth}"
 
 
 @pytest.mark.parametrize(
     "urlpath,expected",
     [
-        ("simplecache::file:///tmp", "/tmp"),
+        pytest.param(
+            "simplecache::file:///tmp",
+            add_current_drive_on_windows("/tmp"),
+        ),
         pytest.param(
             "zip://file.txt::file:///tmp.zip",
             "file.txt",
-            marks=skip_on_windows(None),
         ),
         pytest.param(
-            "zip://file.txt::file:///tmp.zip",
-            f"{CURRENT_DRIVE}/file.txt",
-            marks=only_on_windows(None),
+            "zip://a/b/c.txt::simplecache::memory://zipfile.zip",
+            "a/b/c.txt",
         ),
-        ("zip://a/b/c.txt::simplecache::memory://zipfile.zip", "a/b/c.txt"),
     ],
 )
 def test_chaining_upath_path(urlpath, expected):

--- a/upath/tests/test_chain.py
+++ b/upath/tests/test_chain.py
@@ -1,9 +1,12 @@
+import os
 from pathlib import Path
 
 import pytest
 from fsspec.implementations.memory import MemoryFileSystem
 
 from upath import UPath
+from upath.tests.utils import only_on_windows
+from upath.tests.utils import skip_on_windows
 
 
 @pytest.mark.parametrize(
@@ -18,11 +21,21 @@ def test_chaining_upath_protocol(urlpath, expected):
     assert pth.protocol == expected
 
 
+CURRENT_DRIVE = os.path.splitdrive(Path.cwd().as_posix())[0]
+
+
 @pytest.mark.parametrize(
     "urlpath,expected",
     [
         ("simplecache::file:///tmp", "/tmp"),
-        ("zip://file.txt::file:///tmp.zip", "file.txt"),
+        pytest.param(
+            "zip://file.txt::file:///tmp.zip", "file.txt", marks=skip_on_windows(None)
+        ),
+        pytest.param(
+            "zip://file.txt::file:///tmp.zip",
+            f"{CURRENT_DRIVE}/file.txt",
+            marks=only_on_windows(None),
+        ),
     ],
 )
 def test_chaining_upath_path(urlpath, expected):

--- a/upath/tests/test_chain.py
+++ b/upath/tests/test_chain.py
@@ -21,6 +21,18 @@ def test_chaining_upath_protocol(urlpath, expected):
 @pytest.mark.parametrize(
     "urlpath,expected",
     [
+        ("simplecache::file:///tmp", "/tmp"),
+        ("zip://file.txt::file:///tmp.zip", "file.txt"),
+    ],
+)
+def test_chaining_upath_path(urlpath, expected):
+    pth = UPath(urlpath)
+    assert pth.path == expected
+
+
+@pytest.mark.parametrize(
+    "urlpath,expected",
+    [
         (
             "simplecache::file:///tmp",
             {


### PR DESCRIPTION
Related to https://github.com/fsspec/filesystem_spec/issues/1907

The UPath.path property didn't split chained paths before.
This PR fixes it. and should enable support for just using chained urlpaths.