### PR TITLE
upath.registry: narrow get_upath_class types on protocol

### DIFF
--- a/typesafety/test_upath_types.yml
+++ b/typesafety/test_upath_types.yml
@@ -19,3 +19,64 @@
     b: JoinablePathLike = PurePath()
     c: JoinablePathLike = Path()
     d: JoinablePathLike = UPath()
+
+- case: get_upath_class_fsspec_protocols
+  disable_cache: false
+  parametrized:
+    - cls_fqn: upath.implementations.cached.SimpleCachePath
+      protocol: simplecache
+    - cls_fqn: upath.implementations.cloud.S3Path
+      protocol: s3
+    - cls_fqn: upath.implementations.cloud.GCSPath
+      protocol: gcs
+    - cls_fqn: upath.implementations.cloud.AzurePath
+      protocol: abfs
+    - cls_fqn: upath.implementations.data.DataPath
+      protocol: data
+    - cls_fqn: upath.implementations.github.GitHubPath
+      protocol: github
+    - cls_fqn: upath.implementations.hdfs.HDFSPath
+      protocol: hdfs
+    - cls_fqn: upath.implementations.http.HTTPPath
+      protocol: http
+    - cls_fqn: upath.implementations.local.FilePath
+      protocol: file
+    - cls_fqn: upath.implementations.memory.MemoryPath
+      protocol: memory
+    - cls_fqn: upath.implementations.sftp.SFTPPath
+      protocol: sftp
+    - cls_fqn: upath.implementations.smb.SMBPath
+      protocol: smb
+    - cls_fqn: upath.implementations.webdav.WebdavPath
+      protocol: webdav
+  main: |
+    from upath.registry import get_upath_class
+
+    path_cls = get_upath_class("{{ protocol }}")
+    reveal_type(path_cls)  # N: Revealed type is "type[{{ cls_fqn }}]"
+
+- case: get_upath_class_pathlib_unix
+  disable_cache: false
+  skip: sys.platform == "win32"
+  main: |
+    from upath.registry import get_upath_class
+
+    path_cls = get_upath_class("")
+    reveal_type(path_cls)  # N: Revealed type is "type[upath.implementations.local.PosixUPath]"
+
+- case: get_upath_class_pathlib_win
+  disable_cache: false
+  skip: sys.platform != "win32"
+  main: |
+    from upath.registry import get_upath_class
+
+    path_cls = get_upath_class("")
+    reveal_type(path_cls)  # N: Revealed type is "type[upath.implementations.local.WindowsUPath]"
+
+- case: get_upath_class_unknown_protocol
+  disable_cache: false
+  main: |
+    from upath.registry import get_upath_class
+
+    path_cls = get_upath_class("some-unknown-protocol")
+    reveal_type(path_cls)  # N: Revealed type is "Union[type[upath.core.UPath], None]"

--- a/typesafety/test_upath_types.yml
+++ b/typesafety/test_upath_types.yml
@@ -73,10 +73,20 @@
     path_cls = get_upath_class("")
     reveal_type(path_cls)  # N: Revealed type is "type[upath.implementations.local.WindowsUPath]"
 
-- case: get_upath_class_unknown_protocol
+- case: get_upath_class_unknown_protocol_py39
   disable_cache: false
+  skip: sys.version_info >= (3, 10)
   main: |
     from upath.registry import get_upath_class
 
     path_cls = get_upath_class("some-unknown-protocol")
     reveal_type(path_cls)  # N: Revealed type is "Union[type[upath.core.UPath], None]"
+
+- case: get_upath_class_unknown_protocol_py310plus
+  disable_cache: false
+  skip: sys.version_info < (3, 10)
+  main: |
+    from upath.registry import get_upath_class
+
+    path_cls = get_upath_class("some-unknown-protocol")
+    reveal_type(path_cls)  # N: Revealed type is "type[upath.core.UPath] | None"

--- a/upath/implementations/_experimental.py
+++ b/upath/implementations/_experimental.py
@@ -10,8 +10,17 @@ if TYPE_CHECKING:
 
 def __getattr__(name: str) -> type[UPath]:
     if name.startswith("_") and name.endswith("Path"):
+        from upath import UPath
+
         protocol = name[1:-4].lower()
-        cls = get_upath_class(protocol, fallback=False)
-        assert cls is not None
+        cls = get_upath_class(protocol)
+        if cls is None:
+            raise RuntimeError(
+                f"Could not find fsspec implementation for protocol {protocol!r}"
+            )
+        elif not issubclass(cls, UPath):
+            raise RuntimeError(
+                "UPath implementation not a subclass of upath.UPath, {cls!r}"
+            )
         return cls
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/upath/tests/implementations/test_github.py
+++ b/upath/tests/implementations/test_github.py
@@ -30,6 +30,16 @@ class TestUPathGitHubPath(BaseTests):
         path = "github://ap--:universal_pathlib@test_data/data"
         self.path = UPath(path)
 
+    @pytest.fixture(autouse=True)
+    def _xfail_on_rate_limit_errors(self):
+        try:
+            yield
+        except Exception as e:
+            if "rate limit exceeded" in str(e):
+                pytest.xfail("GitHub API rate limit exceeded")
+            else:
+                raise
+
     def test_is_GitHubPath(self):
         """
         Test that the path is a GitHubPath instance.


### PR DESCRIPTION
provide type overloads to return the correct static type based on protocol.

Related to #415 