### PR TITLE
Upath type narrow on protocol

### DIFF
--- a/typesafety/test_upath_types.yml
+++ b/typesafety/test_upath_types.yml
@@ -123,26 +123,25 @@
     - cls_fqn: upath.core.UPath
       protocol: unknown-protocol
   main: |
-    from upath import UPath
+    import upath
 
-    # without protocol kwarg resolve to UPath
-    reveal_type(UPath("{{ protocol }}://someuri/blah"))  # N: Revealed type is "upath.core.UPath"
-
-    # with protocol kwarg resolve to specific UPath subclass
-    reveal_type(UPath(".", protocol="{{ protocol }}"))  # N: Revealed type is "{{ cls_fqn }}"
+    p = upath.UPath(".", protocol="{{ protocol }}")
+    reveal_type(p)  # N: Revealed type is "{{ cls_fqn }}"
 
 - case: upath__new__empty_protocol
-  disable_cache: false
+  disable_cache: true
   skip: sys.platform == "win32"
   main: |
-    from upath import UPath
+    from upath.core import UPath
 
-    reveal_type(UPath("", protocol=""))  # N: Revealed type is "type[upath.implementations.local.PosixUPath]"
+    p = UPath("asd", protocol="")
+    reveal_type(p)  # N: Revealed type is "upath.implementations.local.PosixUPath"
 
 - case: get_upath_class_pathlib_win
-  disable_cache: false
+  disable_cache: true
   skip: sys.platform != "win32"
   main: |
-    from upath import UPath
+    from upath.core import UPath
 
-    reveal_type(UPath("", protocol=""))  # N: Revealed type is "type[upath.implementations.local.WindowsUPath]"
+    p = UPath("", protocol="")
+    reveal_type(p)  # N: Revealed type is "upath.implementations.local.WindowsUPath"

--- a/typesafety/test_upath_types.yml
+++ b/typesafety/test_upath_types.yml
@@ -90,3 +90,59 @@
 
     path_cls = get_upath_class("some-unknown-protocol")
     reveal_type(path_cls)  # N: Revealed type is "type[upath.core.UPath] | None"
+
+- case: upath__new__fsspec_protocols
+  disable_cache: false
+  parametrized:
+    - cls_fqn: upath.implementations.cached.SimpleCachePath
+      protocol: simplecache
+    - cls_fqn: upath.implementations.cloud.S3Path
+      protocol: s3
+    - cls_fqn: upath.implementations.cloud.GCSPath
+      protocol: gcs
+    - cls_fqn: upath.implementations.cloud.AzurePath
+      protocol: abfs
+    - cls_fqn: upath.implementations.data.DataPath
+      protocol: data
+    - cls_fqn: upath.implementations.github.GitHubPath
+      protocol: github
+    - cls_fqn: upath.implementations.hdfs.HDFSPath
+      protocol: hdfs
+    - cls_fqn: upath.implementations.http.HTTPPath
+      protocol: http
+    - cls_fqn: upath.implementations.local.FilePath
+      protocol: file
+    - cls_fqn: upath.implementations.memory.MemoryPath
+      protocol: memory
+    - cls_fqn: upath.implementations.sftp.SFTPPath
+      protocol: sftp
+    - cls_fqn: upath.implementations.smb.SMBPath
+      protocol: smb
+    - cls_fqn: upath.implementations.webdav.WebdavPath
+      protocol: webdav
+    - cls_fqn: upath.core.UPath
+      protocol: unknown-protocol
+  main: |
+    from upath import UPath
+
+    # without protocol kwarg resolve to UPath
+    reveal_type(UPath("{{ protocol }}://someuri/blah"))  # N: Revealed type is "upath.core.UPath"
+
+    # with protocol kwarg resolve to specific UPath subclass
+    reveal_type(UPath(".", protocol="{{ protocol }}"))  # N: Revealed type is "{{ cls_fqn }}"
+
+- case: upath__new__empty_protocol
+  disable_cache: false
+  skip: sys.platform == "win32"
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("", protocol=""))  # N: Revealed type is "type[upath.implementations.local.PosixUPath]"
+
+- case: get_upath_class_pathlib_win
+  disable_cache: false
+  skip: sys.platform != "win32"
+  main: |
+    from upath import UPath
+
+    reveal_type(UPath("", protocol=""))  # N: Revealed type is "type[upath.implementations.local.WindowsUPath]"

--- a/upath/core.py
+++ b/upath/core.py
@@ -121,7 +121,11 @@ class _UPathMeta(ABCMeta):
         else:
             if isinstance(arg0, UPath) and not kwargs:
                 return copy(arg0)  # type: ignore[return-value]
-        return ABCMeta.__call__(cls, *args, **kwargs)
+        # We do this call manually, because cls could be a registered
+        # subclass of UPath that is not directly inheriting from UPath.
+        inst = cls.__new__(cls, *args, **kwargs)
+        inst.__init__(*args, **kwargs)  # type: ignore[misc]
+        return inst
 
 
 class _UPathMixin(metaclass=_UPathMeta):

--- a/upath/core.py
+++ b/upath/core.py
@@ -295,11 +295,10 @@ class _UPathMixin(metaclass=_UPathMeta):
         protocol: str | None = None,
         chain_parser: FSSpecChainParser = DEFAULT_CHAIN_PARSER,
         **storage_options: Any,
-    ) -> UPath:
+    ) -> Self:
         # narrow type
-        assert issubclass(
-            cls, UPath
-        ), "UPath.__new__ can't instantiate non-UPath classes"
+        if not issubclass(cls, UPath):
+            raise TypeError("UPath.__new__ can't instantiate non-UPath classes")
 
         # deprecate 'scheme'
         if "scheme" in storage_options:
@@ -438,12 +437,134 @@ class UPath(_UPathMixin, WritablePath, ReadablePath):
         "_relative_base",
     )
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:  # noqa: C901
         _chain: Chain
         _chain_parser: FSSpecChainParser
         _fs_cached: bool
         _raw_urlpaths: Sequence[JoinablePathLike]
         _relative_base: str | None
+
+        import upath.implementations as _uimpl
+
+        @overload
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["simplecache"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.cached.SimpleCachePath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["gcs", "gs"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.cloud.GCSPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["s3", "s3a"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.cloud.S3Path: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["az", "abfs", "abfss", "adl"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.cloud.AzurePath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["data"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.data.DataPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["github"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.github.GitHubPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["hdfs"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.hdfs.HDFSPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["http", "https"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.http.HTTPPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["file", "local"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.local.FilePath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["memory"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.memory.MemoryPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["sftp", "ssh"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.sftp.SFTPPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["smb"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.smb.SMBPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: Literal["webdav"],
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> _uimpl.webdav.WebdavPath: ...
+        @overload  # noqa: E301
+        def __new__(
+            cls,
+            *args: JoinablePathLike,
+            protocol: str | None = ...,
+            chain_parser: FSSpecChainParser = ...,
+            **storage_options: Any,
+        ) -> Self: ...
+        def __new__(  # noqa: E301
+            cls,
+            *args: JoinablePathLike,
+            protocol: str | None = None,
+            chain_parser: FSSpecChainParser = DEFAULT_CHAIN_PARSER,
+            **storage_options: Any,
+        ) -> Self: ...
 
     # === JoinablePath attributes =====================================
 

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -432,38 +432,53 @@ class LocalPath(_UPathMixin, pathlib.Path):
 UPath.register(LocalPath)
 
 
-class WindowsUPath(LocalPath, pathlib.WindowsPath):
-    __slots__ = ()
+# Mypy will ignore the ABC.register call above, so we need to force it to
+# think PosixUPath and WindowsUPath are subclasses of UPath.
+# This is really not a good pattern, but it's the best we can do without
+# either introducing a duck-type protocol for UPath or come up with a
+# better solution for the UPath versions of the pathlib.Path subclasses.
 
-    if os.name != "nt":
+if TYPE_CHECKING:
 
-        def __new__(
-            cls,
-            *args,
-            protocol: str | None = None,
-            chain_parser: FSSpecChainParser = DEFAULT_CHAIN_PARSER,
-            **storage_options: Any,
-        ) -> WindowsUPath:
-            raise NotImplementedError(
-                f"cannot instantiate {cls.__name__} on your system"
-            )
+    class WindowsUPath(LocalPath, pathlib.WindowsPath, UPath):  # type: ignore[misc]
+        __slots__ = ()
 
+    class PosixUPath(LocalPath, pathlib.PosixPath, UPath):  # type: ignore[misc]
+        __slots__ = ()
 
-class PosixUPath(LocalPath, pathlib.PosixPath):
-    __slots__ = ()
+else:
 
-    if os.name == "nt":
+    class WindowsUPath(LocalPath, pathlib.WindowsPath):
+        __slots__ = ()
 
-        def __new__(
-            cls,
-            *args,
-            protocol: str | None = None,
-            chain_parser: FSSpecChainParser = DEFAULT_CHAIN_PARSER,
-            **storage_options: Any,
-        ) -> PosixUPath:
-            raise NotImplementedError(
-                f"cannot instantiate {cls.__name__} on your system"
-            )
+        if os.name != "nt":
+
+            def __new__(
+                cls,
+                *args,
+                protocol: str | None = None,
+                chain_parser: FSSpecChainParser = DEFAULT_CHAIN_PARSER,
+                **storage_options: Any,
+            ) -> WindowsUPath:
+                raise NotImplementedError(
+                    f"cannot instantiate {cls.__name__} on your system"
+                )
+
+    class PosixUPath(LocalPath, pathlib.PosixPath):
+        __slots__ = ()
+
+        if os.name == "nt":
+
+            def __new__(
+                cls,
+                *args,
+                protocol: str | None = None,
+                chain_parser: FSSpecChainParser = DEFAULT_CHAIN_PARSER,
+                **storage_options: Any,
+            ) -> PosixUPath:
+                raise NotImplementedError(
+                    f"cannot instantiate {cls.__name__} on your system"
+                )
 
 
 class FilePath(UPath):

--- a/upath/registry.py
+++ b/upath/registry.py
@@ -213,8 +213,7 @@ if TYPE_CHECKING:  # noqa: C901
     def get_upath_class(protocol: Literal["s3", "s3a"]) -> type[_S3Path]: ...
     @overload
     def get_upath_class(protocol: Literal["gcs", "gs"]) -> type[_GCSPath]: ...
-
-    @overload
+    @overload  # noqa: E301
     def get_upath_class(
         protocol: Literal["abfs", "abfss", "adl", "az"],
     ) -> type[_AzurePath]: ...


### PR DESCRIPTION
This PR enables type narrowing of the UPath class instantiation when provided a literal string protocol for the protocol keyword argument.

Close #415 