### PR TITLE
Change protocol check to fallback for known implementations

### DIFF
--- a/upath/_flavour.py
+++ b/upath/_flavour.py
@@ -198,7 +198,7 @@ class WrappedFileSystemFlavour(UPathParser):  # (pathlib_abc.FlavourBase)
         except KeyError:
             pass
         # finally fallback to a default flavour for the protocol
-        if protocol in known_implementations:
+        if protocol not in known_implementations:
             warnings.warn(
                 f"Could not find default for known protocol {protocol!r}."
                 " Creating a default flavour for it. Please report this"


### PR DESCRIPTION
The code below:

```python
from upath import UPath
root_dir = UPath("simplecache::s3://my-bucket")
```

triggers this one-time warning:

```
.pixi/envs/default/lib/python3.13/site-packages/upath/_flavour.py:431: UserWarning: Could not find default for known protocol 'simplecache'. Creating a default flavour for it. Please report this to the universal_pathlib issue tracker.
  return WrappedFileSystemFlavour.from_protocol(protocol).get_kwargs_from_url(url)
```

which I think is a false positive due to a typo.

But I am not sure and maybe I misunderstand the logic here so let me know!

Using the latest version of upath.