### PR TITLE
support JSON schema generation

### DIFF
--- a/upath/tests/test_pydantic.py
+++ b/upath/tests/test_pydantic.py
@@ -111,3 +111,8 @@ def test_dump_non_serializable_json():
         pydantic.TypeAdapter(UPath).dump_python(
             UPath("https://www.example.com", get_client=get_client), mode="json"
         )
+
+
+def test_json_schema():
+    ta = pydantic.TypeAdapter(UPath)
+    ta.json_schema()


### PR DESCRIPTION
This is a follow-up to #395 that fixes #452. While quite elegant, using a plain validator as the first element in the JSON schema (`deserialization_schema`) does not work. There is the option to define it explicitly for the plain validator, but that would mean we need to replicate most of the logic we have for validating the input dictionary.

Instead, this PR creates two separate validation branches for strings and objects:

- If the input is a string, we know how to generate the full object dictionary rather than just the minimal one and let the object schema fill in the default values
- If the input is a dictionary, the plain validator was a no-op to begin with and thus can be skipped.

Roughly we are switching from

```python
def normalize_input_to_dict_old(v: str | dict) -> dict:
    return {"path": v} if isinstance(v, str) else v

def deserialize_old(v: str | dict) -> UPath:
    v = normalize_input_to_dict_old(v)
    v = validate_dict(v)
    return create_upath_from_dict(v)
```

to

```python
def normalize_input_to_dict_new(v: str) -> dict:
    return {"path": v, "protocol": None, "storage_options": {}}

def deserialize_new(v: str | dict) -> UPath:
    if isinstance(v, str):
        v = normalize_input_to_dict_new(v)
    else:
        v = validate_dict(v)
    return create_upath_from_dict(v)
```

The diff looks way larger than it is, because we removed one level of indentation of the large object schema to enhance readability.