### PR TITLE
upath: fix maintainer display on pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 ]
 description = "pathlib api extended to use fsspec backends"
 maintainers = [
+    {name = "Andreas Poehlmann"},
     {name = "Andreas Poehlmann", email = "andreas@poehlmann.io"},
     {name = "Norman Rzepka"},
 ]


### PR DESCRIPTION
The pypi meta section doesn't handle the PKG-INFO metadata well with mixed maintainer and maintainer-email sections. It incorrectly mixes Norman's name with my email. This should likely be fixed in warehouse.

```
# PKG-INFO
Maintainer: Norman Rzepka
Maintainer-email: Andreas Poehlmann <andreas@poehlmann.io>
```

<img width="219" height="307" alt="Screenshot 2025-11-23 at 18 40 17" src="https://github.com/user-attachments/assets/ec7410ee-eaf4-4a59-bae3-216631e6eebf" />

```html
<span>
  <strong>Maintainer:</strong>
  <a href="mailto:andreas@poehlmann.io">Norman Rzepka</a>
</span>
```