### PR TITLE
fix: fix runtime type introspection by moving public API types out of TYPE_CHECKING

### DIFF
--- a/upath/implementations/cloud.py
+++ b/upath/implementations/cloud.py
@@ -2,29 +2,25 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
-from typing import Any
+from typing import Any, Literal
 
-from upath._chain import DEFAULT_CHAIN_PARSER
+from upath._chain import DEFAULT_CHAIN_PARSER, FSSpecChainParser
 from upath._flavour import upath_strip_protocol
 from upath.core import UPath
 from upath.types import JoinablePathLike
+from upath.types.storage_options import (
+    AzureStorageOptions,
+    GCSStorageOptions,
+    HfStorageOptions,
+    S3StorageOptions,
+)
 
-if TYPE_CHECKING:
-    from typing import Literal
-
-    if sys.version_info >= (3, 11):
-        from typing import Self
-        from typing import Unpack
-    else:
-        from typing_extensions import Self
-        from typing_extensions import Unpack
-
-    from upath._chain import FSSpecChainParser
-    from upath.types.storage_options import AzureStorageOptions
-    from upath.types.storage_options import GCSStorageOptions
-    from upath.types.storage_options import HfStorageOptions
-    from upath.types.storage_options import S3StorageOptions
+if sys.version_info >= (3, 11):
+    from typing import Self
+    from typing import Unpack
+else:
+    from typing_extensions import Self
+    from typing_extensions import Unpack
 
 __all__ = [
     "CloudPath",


### PR DESCRIPTION
# Problem

Classes like `S3Path`, `GCSPath` etc. have type annotations in their `__init__` 
that reference types only imported under `if TYPE_CHECKING:`. This breaks runtime 
type introspection tools that call `typing.get_type_hints()`, such as:

- tyro (CLI generation)
- pydantic (validation)
- dataclasses with type validation

here is a quick reproduce:

```python
from typing import get_type_hints

from upath import UPath

s3_path = UPath("s3://bucket/path")
S3Path = type(s3_path)

hints = get_type_hints(S3Path.__init__)
# will raise error
```

## Root Cause

When `from __future__ import annotations` is used, all annotations become strings.
`get_type_hints()` evaluates these strings in the module's namespace. Types under
`TYPE_CHECKING` don't exist at runtime, causing `NameError`.

## Solution

Move types used in public API signatures out of `TYPE_CHECKING` block and import
them unconditionally. These are all lightweight imports with no performance impact:

- `Literal` - typing primitive
- `FSSpecChainParser` - already imported elsewhere
- `Unpack`, `Self` - typing utilities
- Storage options - TypedDict definitions