### PR TITLE
Use fsid for path equality instead of storage_options

### DIFF
--- a/upath/_fsid.py
+++ b/upath/_fsid.py
@@ -1,0 +1,129 @@
+"""Filesystem identity (fsid) fallback computation.
+
+This module provides `_fallback_fsid` to compute filesystem identity from
+protocol, storage_options, and fsspec global config (`fsspec.config.conf`)
+without instantiating the filesystem.
+
+The fsid is used by __eq__, relative_to, and is_relative_to to determine
+if two paths are on the same filesystem. The key insight is that many
+storage_options (like authentication or performance settings) don't affect
+*which* filesystem is being accessed, only *how* it's accessed.
+
+For filesystems where fsid cannot be determined (e.g., memory filesystem,
+unknown protocols), returns None and callers fall back to comparing
+storage_options directly.
+"""
+
+from __future__ import annotations
+
+from collections import ChainMap
+from collections.abc import Mapping
+from typing import Any
+
+from fsspec.config import conf as fsspec_conf
+from fsspec.utils import tokenize
+
+__all__ = ["_fallback_fsid"]
+
+
+def _fallback_fsid(protocol: str, storage_options: Mapping[str, Any]) -> str | None:
+    """Compute fsid from protocol, storage_options, and fsspec global config."""
+    global_opts = fsspec_conf.get(protocol)
+    opts: Mapping[str, Any] = (
+        ChainMap(storage_options, global_opts)  # type: ignore[arg-type]
+        if global_opts
+        else storage_options
+    )
+
+    match protocol:
+        # Static fsid (no instance attributes needed)
+        case "" | "file" | "local":
+            return "local"
+        case "http" | "https":
+            return "http"
+        case "memory" | "memfs":
+            return None  # Non-durable, fall back to storage_options
+        case "data":
+            return None  # Non-durable
+
+        # Host + port based
+        case "sftp" | "ssh":
+            host = opts.get("host", "")
+            port = opts.get("port", 22)
+            return f"sftp_{tokenize(host, port)}" if host else None
+        case "smb":
+            host = opts.get("host", "")
+            port = opts.get("port", 445)
+            return f"smb_{tokenize(host, port)}" if host else None
+        case "ftp":
+            host = opts.get("host", "")
+            port = opts.get("port", 21)
+            return f"ftp_{tokenize(host, port)}" if host else None
+        case "webhdfs" | "webHDFS":
+            host = opts.get("host", "")
+            port = opts.get("port", 50070)
+            return f"webhdfs_{tokenize(host, port)}" if host else None
+
+        # Cloud object storage
+        case "s3" | "s3a":
+            endpoint = opts.get("endpoint_url", "https://s3.amazonaws.com")
+            # Normalize AWS endpoints
+            from urllib.parse import urlparse
+
+            parsed = urlparse(endpoint)
+            if parsed.netloc.endswith(".amazonaws.com"):
+                return "s3_aws"
+            return f"s3_{tokenize(endpoint)}"
+        case "gcs" | "gs":
+            return "gcs"  # Single global endpoint
+        case "abfs" | "az":
+            account = opts.get("account_name", "")
+            return f"abfs_{tokenize(account)}" if account else None
+        case "adl":
+            tenant = opts.get("tenant_id", "")
+            store = opts.get("store_name", "")
+            return f"adl_{tokenize(tenant, store)}" if tenant and store else None
+        case "oci":
+            region = opts.get("region", "")
+            return f"oci_{tokenize(region)}" if region else None
+        case "oss":
+            endpoint = opts.get("endpoint", "")
+            return f"oss_{tokenize(endpoint)}" if endpoint else None
+
+        # Git-based
+        case "git":
+            path = opts.get("path", "")
+            ref = opts.get("ref", "")
+            return f"git_{tokenize(path, ref)}" if path else None
+        case "github":
+            org = opts.get("org", "")
+            repo = opts.get("repo", "")
+            sha = opts.get("sha", "")
+            return f"github_{tokenize(org, repo, sha)}" if org and repo else None
+
+        # Platform-specific
+        case "hf":
+            endpoint = opts.get("endpoint", "huggingface.co")
+            return f"hf_{tokenize(endpoint)}"
+        case "lakefs":
+            host = opts.get("host", "")
+            return f"lakefs_{tokenize(host)}" if host else None
+        case "webdav":
+            base_url = opts.get("base_url", "")
+            return f"webdav_{tokenize(base_url)}" if base_url else None
+        case "box":
+            return "box"
+        case "dropbox":
+            return "dropbox"
+
+        # Wrappers - delegate to underlying
+        case "simplecache" | "filecache" | "blockcache" | "cached":
+            return None  # Complex, fall back
+
+        # Archive filesystems - need underlying fs info
+        case "zip" | "tar":
+            return None  # Complex, fall back
+
+        # Default: unknown protocol, fall back to storage_options
+        case _:
+            return None

--- a/upath/extensions.py
+++ b/upath/extensions.py
@@ -456,6 +456,10 @@ class ProxyUPath:
         return self.__wrapped__.fs
 
     @property
+    def fsid(self) -> str | None:
+        return self.__wrapped__.fsid
+
+    @property
     def path(self) -> str:
         return self.__wrapped__.path
 

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -217,11 +217,12 @@ class LocalPath(_UPathMixin, pathlib.Path):
         eq_path = super().__eq__(other)
         if eq_path is NotImplemented:
             return NotImplemented
-        return (
-            eq_path
-            and self.protocol == other.protocol
-            and self.storage_options == other.storage_options
-        )
+        if not eq_path or self.protocol != other.protocol:
+            return False
+        fsid1, fsid2 = self.fsid, other.fsid
+        if fsid1 is not None and fsid2 is not None:
+            return fsid1 == fsid2
+        return self.storage_options == other.storage_options
 
     def __ne__(self, other: object) -> bool:
         if not isinstance(other, UPath):
@@ -229,11 +230,12 @@ class LocalPath(_UPathMixin, pathlib.Path):
         ne_path = super().__ne__(other)
         if ne_path is NotImplemented:
             return NotImplemented
-        return (
-            ne_path
-            or self.protocol != other.protocol
-            or self.storage_options != other.storage_options
-        )
+        if ne_path or self.protocol != other.protocol:
+            return True
+        fsid1, fsid2 = self.fsid, other.fsid
+        if fsid1 is not None and fsid2 is not None:
+            return fsid1 != fsid2
+        return self.storage_options != other.storage_options
 
     def __hash__(self) -> int:
         return super().__hash__()

--- a/upath/tests/cases.py
+++ b/upath/tests/cases.py
@@ -185,8 +185,13 @@ class JoinablePathTests:
         p1 = cls(str(self.path), test_extra=1, **self.path.storage_options)
         p2 = cls(str(self.path), test_extra=2, **self.path.storage_options)
         assert p0 == p1
-        assert p0 != p2
-        assert p1 != p2
+        # When fsid is defined, paths with same path and fsid are equal
+        # regardless of storage_options. When fsid is None, paths fall back
+        # to storage_options comparison.
+        if p0.fsid is not None:
+            assert p0 == p2  # Same fsid, so equal despite different storage_options
+        else:
+            assert p0 != p2  # No fsid, falls back to storage_options comparison
 
     def test_relative_to(self):
         base = self.path

--- a/upath/tests/test_core.py
+++ b/upath/tests/test_core.py
@@ -342,10 +342,13 @@ def test_relative_to():
     with pytest.raises(ValueError):
         UPath("s3://test_bucket/file.txt").relative_to(UPath("gcs://test_bucket"))
 
-    with pytest.raises(ValueError):
+    # S3 paths with different auth options but same endpoint should work
+    # (they have the same fsid "s3_aws")
+    assert "file.txt" == str(
         UPath("s3://test_bucket/file.txt", anon=True).relative_to(
             UPath("s3://test_bucket", anon=False)
         )
+    )
 
 
 def test_uri_parsing():

--- a/upath/tests/test_fsid.py
+++ b/upath/tests/test_fsid.py
@@ -1,0 +1,191 @@
+"""Tests for fsid-based path equivalence."""
+
+import pytest
+
+from upath import UPath
+
+
+# --- __eq__ tests ---
+
+
+def test_eq_with_fsid_local(tmp_path):
+    """Local paths with different storage_options should be equal."""
+    p1 = UPath(tmp_path / "test.txt")
+    p2 = UPath(tmp_path / "test.txt", auto_mkdir=True)
+    assert p1 == p2
+
+
+def test_eq_with_fsid_http():
+    """HTTP paths with different storage_options should be equal."""
+    p1 = UPath("http://example.com/file.txt")
+    p2 = UPath("http://example.com/file.txt", block_size=1024)
+    assert p1 == p2
+
+
+def test_eq_http_https_different_protocol():
+    """HTTP and HTTPS are different protocols, so paths are not equal."""
+    p1 = UPath("http://example.com/file.txt")
+    p2 = UPath("https://example.com/file.txt")
+    assert p1 != p2
+
+
+def test_eq_different_filesystem():
+    """Paths on different filesystems should not be equal."""
+    p1 = UPath("/tmp/file.txt")
+    p2 = UPath("memory:///tmp/file.txt")
+    assert p1 != p2
+
+
+def test_eq_s3_same_endpoint():
+    """S3 paths with same endpoint but different auth should be equal."""
+    p1 = UPath("s3://bucket/key")
+    p2 = UPath("s3://bucket/key", anon=True)
+    assert p1 == p2
+
+
+def test_eq_s3_different_endpoint():
+    """S3 paths with different endpoints should not be equal."""
+    p1 = UPath("s3://bucket/key")
+    p2 = UPath("s3://bucket/key", endpoint_url="http://localhost:9000")
+    assert p1 != p2
+
+
+# --- relative_to tests ---
+
+
+def test_relative_to_with_fsid(tmp_path):
+    """relative_to should work when fsids match."""
+    p1 = UPath(tmp_path / "dir" / "file.txt")
+    p2 = UPath(tmp_path / "dir", auto_mkdir=True)
+    rel = p1.relative_to(p2)
+    assert str(rel) == "file.txt"
+
+
+def test_relative_to_different_fsid():
+    """relative_to should raise when fsids differ."""
+    p1 = UPath("s3://bucket/dir/file.txt")
+    p2 = UPath("s3://bucket/dir", endpoint_url="http://localhost:9000")
+    with pytest.raises(ValueError, match="incompatible filesystems"):
+        p1.relative_to(p2)
+
+
+# --- is_relative_to tests ---
+
+
+def test_is_relative_to_with_fsid(tmp_path):
+    """is_relative_to should return True when fsids match."""
+    p1 = UPath(tmp_path / "dir" / "file.txt")
+    p2 = UPath(tmp_path / "dir", auto_mkdir=True)
+    assert p1.is_relative_to(p2)
+
+
+def test_is_relative_to_different_fsid():
+    """is_relative_to should return False when fsids differ."""
+    p1 = UPath("s3://bucket/dir/file.txt")
+    p2 = UPath("s3://bucket/dir", endpoint_url="http://localhost:9000")
+    assert not p1.is_relative_to(p2)
+
+
+# --- _fallback_fsid audit tests ---
+# These tests verify that our fallback fsid computation matches
+# the native fsid implementations in fsspec filesystems.
+
+
+def test_fallback_matches_local_filesystem():
+    """Verify _fallback_fsid matches LocalFileSystem.fsid."""
+    from upath._fsid import _fallback_fsid
+
+    p = UPath("/tmp/test.txt")
+    native_fsid = p.fs.fsid
+    fallback_fsid = _fallback_fsid(p.protocol, p.storage_options)
+    assert native_fsid == fallback_fsid == "local"
+
+
+def test_fallback_matches_http_filesystem():
+    """Verify _fallback_fsid matches HTTPFileSystem.fsid."""
+    from upath._fsid import _fallback_fsid
+
+    for url in ["http://example.com/file.txt", "https://example.com/file.txt"]:
+        p = UPath(url)
+        native_fsid = p.fs.fsid
+        fallback_fsid = _fallback_fsid(p.protocol, p.storage_options)
+        assert native_fsid == fallback_fsid == "http"
+
+
+def test_fsid_consistency_cached_vs_uncached(tmp_path):
+    """Verify fsid is consistent whether filesystem is cached or not."""
+    # Create two paths - check fsid before and after fs access
+    p1 = UPath(tmp_path / "test.txt")
+    p2 = UPath(tmp_path / "test.txt", auto_mkdir=True)
+
+    # Before any fs access (uses fallback)
+    fsid1_before = p1.fsid
+    fsid2_before = p2.fsid
+
+    # Access fs on p1 only (p1 now uses cached fs.fsid)
+    _ = p1.fs
+    fsid1_after = p1.fsid
+    fsid2_still_fallback = p2.fsid
+
+    # All should be equal
+    assert fsid1_before == fsid2_before == fsid1_after == fsid2_still_fallback == "local"
+
+
+def test_fallback_uses_global_config():
+    """Verify _fallback_fsid incorporates fsspec global config."""
+    from fsspec.config import conf as fsspec_conf
+
+    from upath._fsid import _fallback_fsid
+
+    # Before setting config - default AWS
+    assert _fallback_fsid("s3", {}) == "s3_aws"
+
+    # Set global config
+    fsspec_conf["s3"] = {"endpoint_url": "http://minio.local:9000"}
+    try:
+        # Should now use the global config endpoint
+        fsid_with_config = _fallback_fsid("s3", {})
+        assert fsid_with_config != "s3_aws"
+        assert fsid_with_config.startswith("s3_")
+
+        # Explicit storage_options should override global config
+        assert _fallback_fsid("s3", {"endpoint_url": "https://s3.amazonaws.com"}) == "s3_aws"
+    finally:
+        # Clean up
+        del fsspec_conf["s3"]
+
+
+def test_fallback_ignores_auth_options():
+    """Verify auth options don't affect fsid."""
+    from upath._fsid import _fallback_fsid
+
+    base = _fallback_fsid("s3", {})
+    with_anon = _fallback_fsid("s3", {"anon": True})
+    with_key = _fallback_fsid("s3", {"key": "xxx", "secret": "yyy"})
+
+    assert base == with_anon == with_key == "s3_aws"
+
+
+def test_fallback_respects_identity_options():
+    """Verify identity-relevant options produce different fsids."""
+    from upath._fsid import _fallback_fsid
+
+    # S3: different endpoints = different fsid
+    aws = _fallback_fsid("s3", {})
+    minio = _fallback_fsid("s3", {"endpoint_url": "http://localhost:9000"})
+    assert aws != minio
+
+    # SFTP: different hosts = different fsid
+    host1 = _fallback_fsid("sftp", {"host": "server1.com"})
+    host2 = _fallback_fsid("sftp", {"host": "server2.com"})
+    assert host1 != host2
+
+    # SFTP: different ports = different fsid
+    port22 = _fallback_fsid("sftp", {"host": "server.com", "port": 22})
+    port2222 = _fallback_fsid("sftp", {"host": "server.com", "port": 2222})
+    assert port22 != port2222
+
+    # Azure: different accounts = different fsid
+    acc1 = _fallback_fsid("abfs", {"account_name": "storage1"})
+    acc2 = _fallback_fsid("abfs", {"account_name": "storage2"})
+    assert acc1 != acc2

--- a/upath/tests/test_relative.py
+++ b/upath/tests/test_relative.py
@@ -98,10 +98,18 @@ def test_relative_path_validation():
     with pytest.raises(ValueError, match="incompatible protocols"):
         p.relative_to(UPath("s3://bucket"))
 
-    # Different storage options should fail
-    with pytest.raises(ValueError, match="incompatible storage_options"):
+    # S3 paths with different auth options but same endpoint should work
+    # (they have the same fsid "s3_aws")
+    assert "file" == str(
         UPath("s3://bucket/file", anon=True).relative_to(
             UPath("s3://bucket", anon=False)
+        )
+    )
+
+    # Different endpoints should fail (different fsid)
+    with pytest.raises(ValueError, match="incompatible filesystems"):
+        UPath("s3://bucket/file").relative_to(
+            UPath("s3://bucket", endpoint_url="http://localhost:9000")
         )
 
 


### PR DESCRIPTION
## Summary

This PR changes `__eq__`, `relative_to`, and `is_relative_to` to compare paths based on **filesystem identity** (fsid) rather than `storage_options` directly.

Fixes #532

## The Problem

Previously, paths to the same resource were considered unequal if their `storage_options` differed:

```python
# Pre-this-PR: False (unexpected!)
UPath('s3://bucket/file.txt') == UPath('s3://bucket/file.txt', anon=True)

# Pre-this-PR: ValueError (unexpected!)
p1 = UPath('s3://bucket/dir/file.txt', anon=True)
p2 = UPath('s3://bucket/dir')
p1.relative_to(p2)
```

## The Solution

Use **fsid** (filesystem identifier) to determine if two paths are on the same filesystem. The fsid ignores options that don't affect *which* filesystem is accessed (auth, performance settings) while considering options that do (endpoint_url, account_name, host+port).

```python
# Now works as expected
UPath('s3://bucket/file.txt') == UPath('s3://bucket/file.txt', anon=True)  # True
UPath('/tmp/file.txt') == UPath('/tmp/file.txt', auto_mkdir=True)          # True

# Different endpoints are correctly identified as different filesystems
UPath('s3://bucket/file.txt') != UPath('s3://bucket/file.txt', 
    endpoint_url='http://localhost:9000')  # True
```

## Key Implementation Details

- **No filesystem instantiation**: fsid is computed from protocol, storage_options, and fsspec global config (`fsspec.config.conf`) without instantiating the filesystem
- **Fallback behavior**: For filesystems where fsid cannot be determined (memory, unknown protocols), falls back to `storage_options` comparison
- **Returns None instead of raising**: Unlike fsspec's `fs.fsid` which raises `NotImplementedError`, `UPath.fsid` returns `None`
- **Verified against fsspec**: Audit tests ensure our fallback matches native fsid for `LocalFileSystem` and `HTTPFileSystem`
- **No caching**: LRU caching was not added to `_fallback_fsid` due to complexity (would need to handle mutable storage_options dicts) and the minimal cost of computing fsid on the fly. If needed, `UPath.fsid` can be changed to a cached property in the future.

## Changes

- Add `upath/_fsid.py` with `_fallback_fsid()` for computing fsid from protocol + storage_options + global config
- Add `fsid` property to `_UPathMixin` and `ProxyUPath`
- Update `__eq__` in `UPath` and `LocalPath` to use fsid
- Update `relative_to` and `is_relative_to` to use fsid
- Add tests in `upath/tests/test_fsid.py` including audit tests
- Document behavior in migration guide (`docs/migration.md`) and concepts (`docs/concepts/upath.md`)

## Test plan

- [x] All existing tests pass (393 passed)
- [x] New tests for fsid-based equality (16 tests)
- [x] Audit tests verify fallback matches native fsid implementations
- [x] Tests cover local, HTTP, S3, and memory filesystems
- [x] Tests cover `relative_to` and `is_relative_to` with matching/different fsids
- [x] Tests verify global config integration

🤖 Generated with [Claude Code](https://claude.ai/code)