### PR TITLE
Enhance rmdir method with future behavior warning and consistent handling

### DIFF
--- a/upath/core.py
+++ b/upath/core.py
@@ -1880,7 +1880,7 @@ class UPath(_UPathMixin, WritablePath, ReadablePath):
             return
         self.fs.rm(self.path, recursive=False)
 
-    def rmdir(self, recursive: bool = True) -> None:  # fixme: non-standard
+    def rmdir(self, recursive: bool = UNSET_DEFAULT) -> None:  # fixme: non-standard
         """
         Remove this directory.
 
@@ -1896,7 +1896,18 @@ class UPath(_UPathMixin, WritablePath, ReadablePath):
         """
         if not self.is_dir():
             raise NotADirectoryError(str(self))
-        if not recursive and next(self.iterdir()):  # type: ignore[arg-type]
+
+        has_contents = bool(next(self.iterdir()))
+
+        if recursive is UNSET_DEFAULT:
+            if has_contents:
+                warnings.warn(
+                    "This function will change behavior in a future version.",
+                    FutureWarning,
+                )
+            recursive = True
+
+        if not recursive and has_contents:
             raise OSError(f"Not recursive and directory not empty: {self}")
         self.fs.rm(self.path, recursive=recursive)
 

--- a/upath/implementations/local.py
+++ b/upath/implementations/local.py
@@ -362,10 +362,13 @@ class LocalPath(_UPathMixin, pathlib.Path):
         )
 
     def rmdir(self, recursive: bool = UNSET_DEFAULT) -> None:
-        if recursive is UNSET_DEFAULT or not recursive:
-            return super().rmdir()
-        else:
-            shutil.rmtree(self)
+        if recursive is UNSET_DEFAULT:
+            warnings.warn(
+                "This function will change behavior in a future version.", FutureWarning
+            )
+            recursive = True
+
+        return shutil.rmtree(self) if recursive else super().rmdir()
 
     # we need to override pathlib.Path._copy_from to support it as a
     # WritablePath._copy_from target with support for on_name_collision


### PR DESCRIPTION
Improve the rmdir method to provide a warning about an upcoming behavior change and ensure consistent handling of the recursive parameter. Adjustments include using UNSET_DEFAULT for the recursive argument and issuing a warning when the directory is not empty.